### PR TITLE
Add Makefile for build automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: setup build test lint clean \
-       release-node release-python release-cli \
-       publish-node publish-python publish-cli
+       release-node release-python release-cli release-mcp \
+       publish-node publish-python publish-cli publish-mcp
 
 setup:  ## Unix/macOS only — see README.md for Windows notes
 	npm install
@@ -29,9 +29,11 @@ lint:
 #   make release-node VERSION=0.2.0      # → Artifactory
 #   make release-python VERSION=0.2.0    # → Artifactory
 #   make release-cli VERSION=0.2.0       # → Artifactory + GitHub Release
+#   make release-mcp VERSION=0.2.0       # → Artifactory
 #   make publish-node VERSION=0.2.0      # → public npm
 #   make publish-python VERSION=0.2.0    # → public PyPI
 #   make publish-cli VERSION=0.2.0       # → public npm
+#   make publish-mcp VERSION=0.2.0       # → public npm
 # Append -rc to the version for a release candidate build:
 #   make release-node VERSION=0.2.0-rc
 
@@ -77,3 +79,13 @@ publish-cli:
 	$(check-version)
 	$(check-master)
 	git tag "cli-npm-v$(VERSION)" && git push origin "cli-npm-v$(VERSION)"
+
+release-mcp:
+	$(check-version)
+	$(check-master)
+	git tag "mcp-v$(VERSION)" && git push origin "mcp-v$(VERSION)"
+
+publish-mcp:
+	$(check-version)
+	$(check-master)
+	git tag "mcp-npm-v$(VERSION)" && git push origin "mcp-npm-v$(VERSION)"


### PR DESCRIPTION
This pull request updates the `Makefile` to add release and publish commands for the `mcp` package, aligning its workflow with existing packages. The main changes involve new targets and documentation updates to support releasing and publishing `mcp` artifacts.

**Release and publish workflow enhancements:**

* Added `release-mcp` and `publish-mcp` targets to the `.PHONY` declaration to ensure these commands are recognized as valid Makefile targets.
* Documented usage examples for `release-mcp` and `publish-mcp` in the Makefile comments, clarifying their purpose and destination (Artifactory and public npm, respectively).
* Implemented the `release-mcp` target to tag and push a release for the `mcp` package, following the established pattern for other packages.
* Implemented the `publish-mcp` target to tag and push a public npm release for the `mcp` package.