### PR TITLE
Update README for MCP installation instructions

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -2,13 +2,7 @@
 
 MCP (Model Context Protocol) server that exposes Blocks Network consumer operations as tools for AI assistants.
 
-## Setup
-
-```bash
-cd mcp
-npm install
-npm run build
-```
+Get API Key: https://app.blocks.ai/manage/api-keys
 
 ## Environment Variables
 
@@ -21,10 +15,14 @@ All other configuration (keys, endpoints) is resolved automatically from CDM.
 
 ## Installation
 
+```bash
+npm i @blocks-network/mcp-server
+```
+
 ### Claude Code (CLI)
 
 ```bash
-claude mcp add blocks-network -- node /path/to/blocks-sdk/mcp/dist/index.js
+claude mcp add blocks-network -- npx @blocks-network/mcp-server
 ```
 
 Or add to your `.claude/settings.json`:
@@ -33,8 +31,8 @@ Or add to your `.claude/settings.json`:
 {
   "mcpServers": {
     "blocks-network": {
-      "command": "node",
-      "args": ["/path/to/blocks-sdk/mcp/dist/index.js"],
+      "command": "npx",
+      "args": ["@blocks-network/mcp-server"],
       "env": {
         "BLOCKS_API_KEY": "your-api-key"
       }
@@ -51,8 +49,8 @@ Add to your `claude_desktop_config.json`:
 {
   "mcpServers": {
     "blocks-network": {
-      "command": "node",
-      "args": ["/path/to/blocks-sdk/mcp/dist/index.js"],
+      "command": "npx",
+      "args": ["@blocks-network/mcp-server"],
       "env": {
         "BLOCKS_API_KEY": "your-api-key"
       }
@@ -73,8 +71,8 @@ Create an `mcp.json` file:
 {
   "mcpServers": {
     "blocks-network": {
-      "command": "node",
-      "args": ["/path/to/blocks-sdk/mcp/dist/index.js"],
+      "command": "npx",
+      "args": ["@blocks-network/mcp-server"],
       "env": {
         "BLOCKS_API_KEY": "your-api-key"
       }
@@ -91,8 +89,8 @@ Add to your `~/.gemini/settings.json`:
 {
   "mcpServers": {
     "blocks-network": {
-      "command": "node",
-      "args": ["/path/to/blocks-sdk/mcp/dist/index.js"],
+      "command": "npx",
+      "args": ["@blocks-network/mcp-server"],
       "env": {
         "BLOCKS_API_KEY": "your-api-key"
       }


### PR DESCRIPTION
This pull request updates the `mcp/README.md` documentation to streamline setup and usage instructions for the MCP server, focusing on using the published `@blocks-network/mcp-server` package via `npx` instead of running a local build. The changes make it easier for users to install and configure the MCP server and clarify how to obtain an API key.

Documentation improvements:

* Updated setup instructions to direct users to obtain an API key from the Blocks website and clarified installation using `npm i @blocks-network/mcp-server`. [[1]](diffhunk://#diff-bbc432cf1e07824fdbc95e27cadce87efa4198c88f4f42de801c90836e710517L5-R5) [[2]](diffhunk://#diff-bbc432cf1e07824fdbc95e27cadce87efa4198c88f4f42de801c90836e710517R18-R25)
* Replaced all references to running the MCP server with `node /path/to/blocks-sdk/mcp/dist/index.js` with `npx @blocks-network/mcp-server` in configuration examples for `.claude/settings.json`, `claude_desktop_config.json`, `mcp.json`, and `~/.gemini/settings.json`. [[1]](diffhunk://#diff-bbc432cf1e07824fdbc95e27cadce87efa4198c88f4f42de801c90836e710517L36-R35) [[2]](diffhunk://#diff-bbc432cf1e07824fdbc95e27cadce87efa4198c88f4f42de801c90836e710517L54-R53) [[3]](diffhunk://#diff-bbc432cf1e07824fdbc95e27cadce87efa4198c88f4f42de801c90836e710517L76-R75) [[4]](diffhunk://#diff-bbc432cf1e07824fdbc95e27cadce87efa4198c88f4f42de801c90836e710517L94-R93)