### PR TITLE
fix(ci): add id-token permission to CLI npm publish

### DIFF
--- a/.github/workflows/cli-npm-publish.yaml
+++ b/.github/workflows/cli-npm-publish.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:


### PR DESCRIPTION
Enables OIDC-based provenance publishing for the CLI workflow, matching the Node SDK workflow.

The CLI npm publish was failing with a 404 because the NPM_TOKEN expired. The Node SDK workflow succeeded because it has `id-token: write` which allows npm to authenticate via GitHub's OIDC identity provider instead of the token. This adds the same permission to the CLI workflow.