### PR TITLE
fix(ci): skip already-published packages in CLI npm publish

### DIFF
--- a/.github/workflows/cli-npm-publish.yaml
+++ b/.github/workflows/cli-npm-publish.yaml
@@ -96,7 +96,14 @@ jobs:
         run: |
           for pkg_dir in cli-darwin-arm64 cli-darwin-x64 cli-linux-arm64 cli-linux-x64 cli-freebsd-arm64 cli-freebsd-x64 cli-win32-x64; do
             echo "Publishing @blocks-network/${pkg_dir}..."
-            npm publish "./npm/${pkg_dir}" --access public
+            npm publish "./npm/${pkg_dir}" --access public 2>&1 | tee /tmp/npm-publish.log || {
+              if grep -q "EPUBLISHCONFLICT\|You cannot publish over\|already exists" /tmp/npm-publish.log; then
+                echo "Version already published, skipping."
+              else
+                cat /tmp/npm-publish.log
+                exit 1
+              fi
+            }
           done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -104,7 +111,13 @@ jobs:
       - name: Publish wrapper package to npm
         working-directory: cli
         run: |
-          echo "Publishing @blocks-network/cli..."
-          npm publish ./npm/cli --access public
+          npm publish ./npm/cli --access public 2>&1 | tee /tmp/npm-publish.log || {
+            if grep -q "EPUBLISHCONFLICT\|You cannot publish over\|already exists" /tmp/npm-publish.log; then
+              echo "Version already published, skipping."
+            else
+              cat /tmp/npm-publish.log
+              exit 1
+            fi
+          }
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Makes the CLI npm publish step idempotent — if a version already exists on npm, skip it and continue to the next package. Still fails hard on any other error (auth, network, etc).

This allows safe re-runs after partial publish failures without needing to bump the version.