### PR TITLE
ci: grant id-token: write to cli-npm-publish workflow

### DIFF
--- a/.github/workflows/cli-npm-publish.yaml
+++ b/.github/workflows/cli-npm-publish.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary

- Adds `id-token: write` permission to `.github/workflows/cli-npm-publish.yaml`, matching the existing `node-npm-publish.yaml` and `python-pypi-publish.yaml` workflows.

## Why

The `@blocks-network/cli-*` platform packages were migrated to **GitHub Actions OIDC trusted publishing** on npm with the `0.1.61` release. Trusted publishing requires the workflow to mint a short-lived OIDC token, which needs `id-token: write` permission.

Without this permission, the `npm publish` call returns `E404`:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@blocks-network%2fcli-darwin-arm64
```

This is npm's response when the workflow has no valid auth path: the legacy `NODE_AUTH_TOKEN` was deauthorized for the scope when trusted publishing was enabled, and the OIDC token can't be minted because the workflow lacks `id-token: write`.
