### PR TITLE
SDK + CLI v0.1.68: sendMessage adds optional stream flag for request tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Each component (Node SDK, Python SDK, CLI) is versioned independently.
 ### [Unreleased]
 
 #### Added
+- `sendMessage({ stream })` — opt in or out of live streaming per request task. Pass `stream: true` to receive token streaming, or `stream: false` to skip it and get only status updates and the final result. Streaming still requires the agent to support it. Pipe tasks are unaffected. Omitting `stream` keeps today's behavior; a future release will stop streaming request tasks unless you pass `stream: true`, so set it now to be forward-compatible.
 - MCP Server support for Consumer SDK — programmatic access to agent capabilities through the Model Context Protocol
 - `session.listEvents()` for seeding full task timelines from history
 - Agent-side stream APIs now match consumer-side in shape and behavior
@@ -86,6 +87,7 @@ consumer-side task submission, real-time event subscriptions, streaming
 ### [Unreleased]
 
 #### Added
+- `send_message(stream=...)` — opt in or out of live streaming per request task. Pass `stream=True` to receive token streaming, or `stream=False` to skip it and get only status updates and the final result. Streaming still requires the agent to support it. Pipe tasks are unaffected. Omitting `stream` keeps today's behavior; a future release will stop streaming request tasks unless you pass `stream=True`, so set it now to be forward-compatible.
 - `session.list_events()` for seeding full task timelines from history
 - Agent-side stream APIs now match consumer-side interface
 - Agent owners can view full task details for received tasks

--- a/examples/node/bidi-chat/handler.ts
+++ b/examples/node/bidi-chat/handler.ts
@@ -8,8 +8,12 @@ export default async function handler(
   task: StartTaskMessage,
   ctx?: TaskContext,
 ): Promise<HandlerResult> {
-  if (!ctx) {
-    return { artifacts: [{ data: 'no context — nothing streamed', mimeType: 'text/plain' }] };
+  // A bidirectional chat needs a live stream. When streaming wasn't
+  // negotiated (no ctx, or a request consumer opted out via stream:false →
+  // hasStream false, BLOCKS-181), there's nothing to stream — return an
+  // artifact instead of throwing in createStream().
+  if (!ctx || !ctx.hasStream) {
+    return { artifacts: [{ data: 'no stream negotiated — nothing streamed', mimeType: 'text/plain' }] };
   }
 
   const greeting = extractGreeting(task.requestParts);

--- a/examples/node/claude-code/handler.ts
+++ b/examples/node/claude-code/handler.ts
@@ -357,7 +357,10 @@ async function runClaudeSession(
   bashSafetyEnabled: boolean,
   requestModel: string | null,
 ): Promise<HandlerResult> {
-  const stream = await ctx?.createStream();
+  // Stream only when negotiated (request streaming is consumer opt-in,
+  // BLOCKS-181); otherwise createStream() would throw. The code below already
+  // treats stream as optional (stream?.write / stream?.end).
+  const stream = ctx?.hasStream ? await ctx.createStream() : undefined;
 
   try {
     let currentSessionId = sessionId;

--- a/examples/node/echo-stream/README.md
+++ b/examples/node/echo-stream/README.md
@@ -43,6 +43,9 @@ prints the final artifact.
 
 ### Provider side (handler.ts)
 
+- Guarding on `ctx.hasStream` before streaming — request streaming is
+  consumer opt-in (BLOCKS-181), so the handler degrades to an
+  artifact-only response when the consumer didn't opt in
 - `ctx.createStream()` to open an outbound stream
 - `stream.write()` for incremental chunk delivery
 - `await stream.end()` to signal `stream_end` to consumers
@@ -50,7 +53,8 @@ prints the final artifact.
 
 ### Consumer side (echo-stream-consumer.ts)
 
-- `TaskClient.sendMessage()` returning a `TaskSession`
+- `TaskClient.sendMessage({ stream: true })` — opting into request-task
+  streaming — returning a `TaskSession`
 - `session.onStream()` callback for stream discovery
 - `streamRef.open()` to get a `StreamClient`
 - `for await (const ev of stream.events<EchoEvent>())` async iteration (decoded events)
@@ -58,7 +62,12 @@ prints the final artifact.
 
 ## Stream lifecycle
 
-1. The handler calls `ctx.createStream()` to create an outbound stream.
+0. The consumer submits with `stream: true`, opting into request-task
+   streaming. Without it (and once the Phase 2 default flips off), the
+   handler's `hasStream` is false and steps 1–4 are skipped — only the
+   final artifact (step 5) is delivered.
+1. The handler sees `ctx.hasStream === true` and calls `ctx.createStream()`
+   to create an outbound stream.
 2. The consumer receives a `stream_started` event via `session.onStream()`.
 3. The consumer opens the stream with `streamRef.open()` and iterates
    over `stream.events<T>()` (decoded events). `stream.inbound` is the

--- a/examples/node/echo-stream/echo-stream-consumer.ts
+++ b/examples/node/echo-stream/echo-stream-consumer.ts
@@ -54,6 +54,9 @@ async function main() {
   const session = await client.sendMessage({
     agentName: AGENT_NAME,
     requestParts: [{ partId: 'text', text: inputText }],
+    // Request-task streaming is consumer opt-in (BLOCKS-181). Pass stream: true
+    // so this stays forward-compatible once the omitted-flag default flips off.
+    stream: true,
   });
 
   console.log(`Task created: ${session.taskId}`);

--- a/examples/node/echo-stream/handler.ts
+++ b/examples/node/echo-stream/handler.ts
@@ -21,7 +21,11 @@ export default async function handler(
 ): Promise<HandlerResult> {
   const fullText = extractInputText(task.requestParts);
 
-  if (ctx) {
+  // Streaming is negotiated per task: the agent must be stream-capable AND,
+  // for request tasks, the consumer must opt in (extensions.blocks.stream).
+  // When hasStream is false, createStream() would throw — so guard on it and
+  // degrade gracefully to returning only the final artifact.
+  if (ctx?.hasStream) {
     ctx.reportStatus('Streaming echo output...');
     // createStream negotiates a dedicated channel for streaming via the streamSetup handshake
     const stream = await ctx.createStream({

--- a/examples/python/bidi-chat/handler.py
+++ b/examples/python/bidi-chat/handler.py
@@ -13,8 +13,12 @@ from blocks_network.types import StartTaskMessage, TaskContext
 
 
 def handler(task: StartTaskMessage, ctx: Optional[TaskContext] = None) -> Dict[str, Any]:
-    if ctx is None:
-        return {"artifacts": [{"data": "no context — nothing streamed", "mimeType": "text/plain"}]}
+    # A bidirectional chat needs a live stream. When streaming wasn't
+    # negotiated (no ctx, or a request consumer opted out via stream=False →
+    # has_stream false, BLOCKS-181), there's nothing to stream — return an
+    # artifact instead of raising in create_stream().
+    if ctx is None or not ctx.has_stream:
+        return {"artifacts": [{"data": "no stream negotiated — nothing streamed", "mimeType": "text/plain"}]}
 
     greeting = _extract_greeting(task.request_parts or [])
 

--- a/examples/python/claude-code/handler.py
+++ b/examples/python/claude-code/handler.py
@@ -433,7 +433,10 @@ async def _run_claude_session(
         bash_safety_enabled: Whether to monitor for dangerous bash commands.
         request_model: Model from request_parts (overrides CLAUDE_MODEL env var).
     """
-    stream = ctx.create_stream() if ctx else None
+    # Stream only when negotiated (request streaming is consumer opt-in,
+    # BLOCKS-181); otherwise create_stream() would raise. The code below
+    # already treats stream as optional.
+    stream = ctx.create_stream() if ctx and ctx.has_stream else None
 
     try:
         tool_call_count = 0

--- a/examples/python/echo-stream/README.md
+++ b/examples/python/echo-stream/README.md
@@ -26,6 +26,9 @@ blocks run
 
 ## SDK concepts demonstrated
 
+- Guarding on `ctx.has_stream` before streaming — request streaming is
+  consumer opt-in (BLOCKS-181), so the handler degrades to an
+  artifact-only response when the consumer didn't opt in
 - `ctx.create_stream()` to open an outbound stream
 - `stream.write()` for incremental chunk delivery
 - `stream.end()` to signal `stream_end` to consumers
@@ -33,7 +36,12 @@ blocks run
 
 ## Stream lifecycle
 
-1. The handler calls `ctx.create_stream()` to create an outbound stream.
+0. The consumer submits with `stream=True`, opting into request-task
+   streaming. Without it (and once the Phase 2 default flips off),
+   `has_stream` is false and steps 1–4 are skipped — only the final
+   artifact (step 5) is delivered.
+1. The handler sees `ctx.has_stream` is true and calls `ctx.create_stream()`
+   to create an outbound stream.
 2. Consumers receive a `stream_started` event and open the stream.
 3. The handler writes chunks with `stream.write()`.
 4. The handler calls `stream.end()`, publishing a `stream_end` marker.

--- a/examples/python/echo-stream/handler.py
+++ b/examples/python/echo-stream/handler.py
@@ -20,7 +20,11 @@ def handler(task: StartTaskMessage, ctx: Optional[TaskContext] = None) -> Dict[s
     """Handle an incoming task by streaming the echo before returning artifact."""
     full_text = _extract_input_text(task.request_parts or [])
 
-    if ctx:
+    # Streaming is negotiated per task: the agent must be stream-capable AND,
+    # for request tasks, the consumer must opt in (extensions.blocks.stream).
+    # When has_stream is False, create_stream() would raise — so guard on it
+    # and degrade gracefully to returning only the final artifact.
+    if ctx and ctx.has_stream:
         ctx.report_status("Streaming echo output...")
         # create_stream negotiates a dedicated channel for streaming via the streamSetup handshake
         stream = ctx.create_stream(

--- a/sdks/node/src/runtime/task-client.ts
+++ b/sdks/node/src/runtime/task-client.ts
@@ -129,6 +129,15 @@ export interface SendMessageParams {
   duration?: number;
   /** Consumer's public key for E2E encryption. Included in extensions.blocks. */
   consumerPublicKey?: string;
+  /**
+   * Request live streaming for this task (request tasks only). When `true`,
+   * the task streams token output if the agent supports it; when `false`,
+   * streaming is suppressed and you receive only status updates and the
+   * final result. Omitted leaves the server default in place. Ignored for
+   * pipe tasks (pipe streaming is capability-driven). Sent as
+   * `extensions.blocks.stream`.
+   */
+  stream?: boolean;
   pushNotificationConfig?: {
     url: string;
     filter?: string;
@@ -962,6 +971,7 @@ export class TaskClient {
     if (taskKind) blocksExt.taskKind = taskKind;
     if (duration !== undefined && duration !== null) blocksExt.duration = duration;
     if (params.consumerPublicKey) blocksExt.consumerPublicKey = params.consumerPublicKey;
+    if (params.stream !== undefined) blocksExt.stream = params.stream;
 
     if (Object.keys(blocksExt).length > 0) {
       rpcParams.extensions = { blocks: blocksExt };

--- a/sdks/node/tests/taskClient.test.ts
+++ b/sdks/node/tests/taskClient.test.ts
@@ -505,6 +505,60 @@ describe('TaskClient', () => {
       session.close();
     });
 
+    it('includes extensions.blocks.stream: true when stream is true', async () => {
+      fetchSpy.mockResolvedValueOnce(mockRpcResponse(fullResponse({ taskId: 'stream-on' })));
+
+      const client = new TaskClient({ billingMode: 'free', subscribeKey: 'sub-c-test', baseUrl: 'http://localhost:3001' });
+
+      const session = await client.sendMessage({
+        agentName: 'agent-b',
+        requestParts: [],
+        ownerId: 'test-user',
+        stream: true,
+      });
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.params.extensions).toEqual({ blocks: { stream: true } });
+
+      session.close();
+    });
+
+    it('includes extensions.blocks.stream: false when stream is false', async () => {
+      fetchSpy.mockResolvedValueOnce(mockRpcResponse(fullResponse({ taskId: 'stream-off' })));
+
+      const client = new TaskClient({ billingMode: 'free', subscribeKey: 'sub-c-test', baseUrl: 'http://localhost:3001' });
+
+      const session = await client.sendMessage({
+        agentName: 'agent-b',
+        requestParts: [],
+        ownerId: 'test-user',
+        stream: false,
+      });
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.params.extensions).toEqual({ blocks: { stream: false } });
+
+      session.close();
+    });
+
+    it('omits extensions.blocks.stream when stream is not supplied', async () => {
+      fetchSpy.mockResolvedValueOnce(mockRpcResponse(fullResponse({ taskId: 'stream-omit' })));
+
+      const client = new TaskClient({ billingMode: 'free', subscribeKey: 'sub-c-test', baseUrl: 'http://localhost:3001' });
+
+      const session = await client.sendMessage({
+        agentName: 'agent-b',
+        requestParts: [],
+        ownerId: 'test-user',
+      });
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      // No extensions object at all when no blocks fields are set.
+      expect(body.params.extensions).toBeUndefined();
+
+      session.close();
+    });
+
     it('rejects pipe tasks without duration before sending RPC', async () => {
       const client = new TaskClient({ billingMode: 'free', subscribeKey: 'sub-c-test', baseUrl: 'http://localhost:3001' });
 

--- a/sdks/python/blocks_network/task_client.py
+++ b/sdks/python/blocks_network/task_client.py
@@ -99,6 +99,12 @@ class SendMessageParams:
     task_kind: Optional[str] = None
     duration: Optional[int] = None
     consumer_public_key: Optional[str] = None
+    # Request live streaming for this task (request tasks only). ``True``
+    # streams token output if the agent supports it; ``False`` suppresses
+    # streaming (status updates + final result only); ``None`` leaves the
+    # server default in place. Ignored for pipe tasks. Sent as
+    # ``extensions.blocks.stream``.
+    stream: Optional[bool] = None
     push_notification_config: Optional[Dict[str, Any]] = None
     retry_policy: Optional[Dict[str, Any]] = None
     auto_drain: Optional[bool] = None
@@ -882,6 +888,7 @@ class TaskClient:
         task_kind: Optional[str] = None,
         duration: Optional[int] = None,
         consumer_public_key: Optional[str] = None,
+        stream: Optional[bool] = None,
         push_notification_config: Optional[Dict[str, Any]] = None,
         retry_policy: Optional[Dict[str, Any]] = None,
         auto_drain: Optional[bool] = None,
@@ -925,6 +932,7 @@ class TaskClient:
             task_kind=task_kind,
             duration=duration,
             consumer_public_key=consumer_public_key,
+            stream=stream,
             push_notification_config=push_notification_config,
             retry_policy=retry_policy,
             auto_drain=auto_drain,
@@ -1046,8 +1054,10 @@ class TaskClient:
         if upload_session_id:
             rpc_params["uploadSessionId"] = upload_session_id
 
-        # Build extensions.blocks with task_kind, duration, and consumer_public_key
+        # Build extensions.blocks with stream, task_kind, duration, and consumer_public_key
         blocks_ext: Dict[str, Any] = {}
+        if params.stream is not None:
+            blocks_ext["stream"] = params.stream
         if task_kind:
             blocks_ext["taskKind"] = task_kind
         if duration is not None:

--- a/sdks/python/tests/test_p4_hardening.py
+++ b/sdks/python/tests/test_p4_hardening.py
@@ -35,6 +35,13 @@ class MockPubNub:
         self._listener = None
         self._subscribed_channels: List[str] = []
         self.publish_calls: List[Dict[str, Any]] = []
+        # Real PubNub stamps each message with a unique timetoken, which
+        # TaskSession uses to dedup replays. Hand out a distinct one per message:
+        # leaving it unset makes the listener stringify an auto-vivified MagicMock
+        # whose repr embeds id(obj), and a GC'd mock's address can be reused — so
+        # two distinct messages collide and the second is silently dropped (a
+        # flaky, GC/interpreter-version-dependent failure).
+        self._next_timetoken = 17_000_000_000_000_000
 
     def add_listener(self, listener):
         self._listener = listener
@@ -56,9 +63,11 @@ class MockPubNub:
 
     def simulate_message(self, channel: str, message: dict):
         if self._listener and hasattr(self._listener, "message"):
+            self._next_timetoken += 1
             evt = MagicMock()
             evt.channel = channel
             evt.message = message
+            evt.timetoken = str(self._next_timetoken)
             self._listener.message(self._listener, evt)
 
 

--- a/sdks/python/tests/test_task_client.py
+++ b/sdks/python/tests/test_task_client.py
@@ -575,6 +575,75 @@ class TestSendMessage:
 
         session.close()
 
+    @patch("blocks_network.task_client.TaskClient._create_session_pubnub")
+    @patch("blocks_network.rpc_client.urllib.request.urlopen")
+    def test_includes_stream_true(self, mock_urlopen, mock_create_pn):
+        mock_urlopen.return_value = _mock_urlopen_response(
+            self._full_response(taskId="stream-on")
+        )
+        fake = create_fake_pubnub()
+        mock_create_pn.return_value = fake["pubnub"]
+
+        client = TaskClient(subscribe_key="sub-c-test", billing_mode="free", base_url="http://localhost:3001")
+        session = client.send_message(
+            agent_name="agent-b",
+            request_parts=[],
+            owner_id="test-user",
+            stream=True,
+        )
+
+        req = mock_urlopen.call_args[0][0]
+        body = json.loads(req.data.decode("utf-8"))
+        assert body["params"]["extensions"] == {"blocks": {"stream": True}}
+
+        session.close()
+
+    @patch("blocks_network.task_client.TaskClient._create_session_pubnub")
+    @patch("blocks_network.rpc_client.urllib.request.urlopen")
+    def test_includes_stream_false(self, mock_urlopen, mock_create_pn):
+        mock_urlopen.return_value = _mock_urlopen_response(
+            self._full_response(taskId="stream-off")
+        )
+        fake = create_fake_pubnub()
+        mock_create_pn.return_value = fake["pubnub"]
+
+        client = TaskClient(subscribe_key="sub-c-test", billing_mode="free", base_url="http://localhost:3001")
+        session = client.send_message(
+            agent_name="agent-b",
+            request_parts=[],
+            owner_id="test-user",
+            stream=False,
+        )
+
+        req = mock_urlopen.call_args[0][0]
+        body = json.loads(req.data.decode("utf-8"))
+        assert body["params"]["extensions"] == {"blocks": {"stream": False}}
+
+        session.close()
+
+    @patch("blocks_network.task_client.TaskClient._create_session_pubnub")
+    @patch("blocks_network.rpc_client.urllib.request.urlopen")
+    def test_omits_stream_when_not_supplied(self, mock_urlopen, mock_create_pn):
+        mock_urlopen.return_value = _mock_urlopen_response(
+            self._full_response(taskId="stream-omit")
+        )
+        fake = create_fake_pubnub()
+        mock_create_pn.return_value = fake["pubnub"]
+
+        client = TaskClient(subscribe_key="sub-c-test", billing_mode="free", base_url="http://localhost:3001")
+        session = client.send_message(
+            agent_name="agent-b",
+            request_parts=[],
+            owner_id="test-user",
+        )
+
+        req = mock_urlopen.call_args[0][0]
+        body = json.loads(req.data.decode("utf-8"))
+        # No blocks fields set → no extensions object at all.
+        assert "extensions" not in body["params"]
+
+        session.close()
+
     @patch("blocks_network.rpc_client.urllib.request.urlopen")
     def test_rejects_pipe_without_duration(self, mock_urlopen):
         client = TaskClient(subscribe_key="sub-c-test", billing_mode="free", base_url="http://localhost:3001")

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -587,6 +587,15 @@ client.destroy();
 - `billingMode` is **required** and must match the target agent's
   registered `billingMode`. Mismatch is rejected with
   `BillingModeMismatchError`.
+- `sendMessage({ stream })` / `send_message(stream=)` is an optional
+  request-task streaming opt-in (BLOCKS-181): `true` requests live token
+  output, `false` suppresses it (status + final result only), omitted
+  leaves the server default. Resolved streaming still requires agent
+  capability, so `stream: true` against a non-streaming agent yields no
+  stream (soft hint, no error). Ignored for pipe tasks (pipe streaming is
+  capability-driven). A future Phase 2 will flip the omitted-flag default
+  from stream-if-capable to off, so pass `stream: true` explicitly if you
+  rely on streaming.
 - Always `client.destroy()` (and `session.close()` / `await
   session.asyncClose()`) when finished -- they unsubscribe transports.
 - If background token refresh permanently fails (3 retries exhausted),
@@ -753,7 +762,7 @@ is already terminal (live-only data is gone; artifacts persist).
 | `agentName` rejected | Must match `^[a-zA-Z0-9_]+$` -- underscores only, no hyphens. |
 | Stream callback fires but data looks wrong / missed events | Consuming `stream.inbound` instead of `stream.events()` / `stream.bytes()`. |
 | `StreamUnavailableError` on `ref.open()` after reconnect | Stream was never opened during the active phase; live stream data is gone. Artifacts remain on the session. |
-| `"Streaming was not negotiated for this task."` from `createStream()` | Agent card is missing the top-level `streams` block, or `streams` was placed inside `capabilities`. Re-publish after fixing. |
+| `"Streaming was not negotiated for this task."` from `createStream()` | `hasStream` is false. Either the agent card is missing the top-level `streams` block (or it was placed inside `capabilities`) — re-publish after fixing — or, for a request task, the consumer didn't opt in via `extensions.blocks.stream` (BLOCKS-181). Guard handler code on `ctx.hasStream` / `ctx.has_stream` so it degrades to an artifact-only response instead of throwing. |
 | `blocks check` rejects extra keys under `capabilities` | `capabilities` only accepts `taskKinds`. Streaming config goes in the top-level `streams` block. |
 | `blocks publish` rejects a `direction: "bidirectional"` + `format: "events"` stream | Bidirectional event streams MUST declare both `outboundSchema` and `inboundSchema` (and MUST NOT use `schema`). Unidirectional event streams use a single `schema`; byte streams use `contentType`. See [Streaming Agents](#streaming-agents). |
 | `blocks init` hangs or asks for confirmation | Missing `--yes`, or `--yes` was passed without a name argument (CLI requires `blocks init <name> --yes` non-interactively). Always include both. |

--- a/skills/references/agent-card-reference.md
+++ b/skills/references/agent-card-reference.md
@@ -107,8 +107,12 @@ required on each stream.
 }
 ```
 
-Without the `streams` block, `ctx.createStream()` throws at runtime:
-`"Streaming was not negotiated for this task."`
+`ctx.createStream()` throws `"Streaming was not negotiated for this task."`
+at runtime whenever `hasStream` is false — either the card lacks the `streams`
+block, or (for request tasks) the consumer did not opt in via
+`extensions.blocks.stream` (BLOCKS-181; in Phase 1 an omitted flag still
+defaults on, in Phase 2 it defaults off). Guard handler code on
+`ctx.hasStream` / `ctx.has_stream` before calling it.
 
 ### Full Streaming Agent Card Example
 

--- a/skills/references/agent-development-guide.md
+++ b/skills/references/agent-development-guide.md
@@ -457,7 +457,10 @@ export default async function handler(
   const input = task.requestParts?.[0];
   const text = typeof input === 'string' ? input : 'Hello from streaming agent!';
 
-  if (ctx) {
+  // Guard on hasStream: request-task streaming is consumer opt-in
+  // (BLOCKS-181), so createStream() throws when the consumer didn't opt in.
+  // Degrade to an artifact-only response in that case.
+  if (ctx?.hasStream) {
     ctx.reportStatus('Streaming...');
     const stream = await ctx.createStream({
       declaredStream: 'main-stream',

--- a/skills/references/node-reference.md
+++ b/skills/references/node-reference.md
@@ -88,7 +88,9 @@ export default async function handler(
   const input = task.requestParts?.[0];
   const text = typeof input === 'string' ? input : 'Hello from streaming agent!';
 
-  if (ctx) {
+  // Guard on hasStream — request-task streaming is consumer opt-in
+  // (BLOCKS-181), so createStream() throws when the consumer didn't opt in.
+  if (ctx?.hasStream) {
     ctx.reportStatus('Streaming...');
     const stream = await ctx.createStream({
       declaredStream: 'main-stream',
@@ -138,8 +140,11 @@ export default async function handler(
 `agent-card.json` -- NOT inside `capabilities`. The `capabilities` object only
 accepts `taskKinds` and rejects all other fields (`additionalProperties: false`).
 
-Without the `streams` declaration, `ctx.createStream()` will throw:
-`"Streaming was not negotiated for this task."`
+`ctx.createStream()` throws `"Streaming was not negotiated for this task."`
+whenever `ctx.hasStream` is false — either the card lacks the `streams`
+declaration, or (for request tasks) the consumer didn't opt in via
+`extensions.blocks.stream` (BLOCKS-181). Guard on `ctx.hasStream` before
+calling it.
 
 ### agent-card.json (streams section)
 
@@ -255,7 +260,7 @@ client.destroy();
 
 ## TaskClient & TaskSession
 
-**sendMessage(params)** -- required params: `agentName`, `requestParts`. Optional: `ownerId` (auto-populated from auth), `idempotencyKey`, `taskKind` (`'request'`|`'pipe'`), `duration`, `consumerPublicKey`, `pushNotificationConfig`, `retryPolicy`, `autoDrain`, `drainWindowMs` (default 30_000; overrides the per-session auto-drain window for already-open streams).
+**sendMessage(params)** -- required params: `agentName`, `requestParts`. Optional: `ownerId` (auto-populated from auth), `idempotencyKey`, `taskKind` (`'request'`|`'pipe'`), `duration`, `consumerPublicKey`, `stream` (request-task streaming opt-in — `true` requests streaming, `false` suppresses it; omitted uses the server default; ignored for pipe; resolved `hasStream` still requires agent capability), `pushNotificationConfig`, `retryPolicy`, `autoDrain`, `drainWindowMs` (default 30_000; overrides the per-session auto-drain window for already-open streams).
 
 **TaskClient.connect({ taskId, autoDrain?, drainWindowMs?, role? })** -- returns a `TaskSession`. `drainWindowMs` mirrors the `sendMessage` option so reconnecting consumers can tune the drain window for streams they open via `openAllStreams()` / `onStream`. `role` defaults to `'consumer'` (task submitter — server checks `userId === task.ownerId`); set to `'provider'` when the caller is the agent owner viewing a received task. Provider-role access is scoped by the caller's active org: the agent's org must match the active org resolved from the session `X-Active-Org` header or the credential's org claim, AND the caller must be a current member of that org. Admins with an admin-typed active org get the cross-org bypass; when no active org is resolved at all (legacy callers), the server falls back to admin-bypass / non-admin membership check on the agent's org.
 

--- a/skills/references/python-reference.md
+++ b/skills/references/python-reference.md
@@ -81,9 +81,11 @@ The `ctx` parameter provides handler APIs:
 ## Streaming Handler
 
 <!-- sync: streaming rules duplicated in SKILL.md, agent-card-reference.md, node-reference.md -->
-**Requires** a top-level `streams` block in `agent-card.json`. Without it
-`ctx.create_stream()` throws:
-`"Streaming was not negotiated for this task."`
+**Requires** a top-level `streams` block in `agent-card.json`. `ctx.create_stream()`
+raises `"Streaming was not negotiated for this task."` whenever `ctx.has_stream`
+is false — either the card lacks `streams`, or (for request tasks) the consumer
+didn't opt in via `extensions.blocks.stream` (BLOCKS-181). Guard on
+`ctx.has_stream` before calling it.
 
 Add this to `agent-card.json` (peer of `identity`, `capabilities`, `io`):
 
@@ -130,7 +132,9 @@ def handler(task: StartTaskMessage, ctx: Optional[TaskContext] = None) -> Dict[s
     parts = task.request_parts or []
     text = parts[0].text if parts and hasattr(parts[0], "text") else "Hello!"
 
-    if ctx:
+    # Guard on has_stream — request-task streaming is consumer opt-in
+    # (BLOCKS-181), so create_stream() raises when the consumer didn't opt in.
+    if ctx and ctx.has_stream:
         ctx.report_status("Streaming...")
         stream = ctx.create_stream(
             declared_stream="main-stream",
@@ -194,7 +198,7 @@ def handler(task: StartTaskMessage, ctx: Optional[TaskContext] = None) -> Dict[s
 
 ## TaskClient & TaskSession
 
-**send_message(\*, agent_name, request_parts, ...)** -- all keyword-only. `owner_id` is auto-populated from auth (optional override). Optional: `idempotency_key`, `task_kind` (`"request"`|`"pipe"`), `duration`, `consumer_public_key`, `push_notification_config`, `retry_policy`, `auto_drain`, `drain_window_s` (default 30.0; overrides the per-session auto-drain window for already-open streams). Returns `TaskSession`.
+**send_message(\*, agent_name, request_parts, ...)** -- all keyword-only. `owner_id` is auto-populated from auth (optional override). Optional: `idempotency_key`, `task_kind` (`"request"`|`"pipe"`), `duration`, `consumer_public_key`, `stream` (request-task streaming opt-in — `True` requests streaming, `False` suppresses it; omitted uses the server default; ignored for pipe; resolved `has_stream` still requires agent capability), `push_notification_config`, `retry_policy`, `auto_drain`, `drain_window_s` (default 30.0; overrides the per-session auto-drain window for already-open streams). Returns `TaskSession`.
 
 **TaskClient.connect(task_id, auto_drain=True, drain_window_s=None, role="consumer")** -- returns a `TaskSession`. `drain_window_s` mirrors `send_message` so reconnecting consumers can tune the drain window for streams they open via `open_all_streams()` / `on_stream`. `role` defaults to `"consumer"` (task submitter — server checks `user_id == task.owner_id`); set to `"provider"` when the caller is the agent owner viewing a received task. Provider-role access is scoped by the caller's active org: the agent's org must match the active org resolved from the session `X-Active-Org` header or the credential's org claim, AND the caller must be a current member of that org. Admins with an admin-typed active org get the cross-org bypass; when no active org is resolved at all (legacy callers), the server falls back to admin-bypass / non-admin membership check on the agent's org.
 


### PR DESCRIPTION
## Node SDK & Python SDK

### Added
- `sendMessage` now accepts an optional `stream` flag to opt a request task in or out of streamed output. When omitted, behavior is unchanged; the flag is ignored for pipe tasks.
