### PR TITLE
SDK + CLI v0.1.70: No customer-facing changes in this release

### DIFF
--- a/examples/node/echo-stream/package.json
+++ b/examples/node/echo-stream/package.json
@@ -8,7 +8,7 @@
     "check": "blocks check"
   },
   "dependencies": {
-    "@blocks-network/sdk": "^0.0.0",
+    "@blocks-network/sdk": "*",
     "dotenv": "^16.4.5",
     "pubnub": "^8.0.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -926,7 +926,7 @@
     "examples/node/echo-stream": {
       "version": "1.0.0",
       "dependencies": {
-        "@blocks-network/sdk": "^0.0.0",
+        "@blocks-network/sdk": "*",
         "dotenv": "^16.4.5",
         "pubnub": "^8.0.0"
       },


### PR DESCRIPTION
Set echo-stream to "*" to match the other examples, so the workspace copy always satisfies the range. Updated both package.json and the corresponding package-lock.json workspace entry.
