### PR TITLE
SDK + CLI v1.0.2: Add multi-turn chat-agent example for Node and Python

### DIFF
--- a/examples/node/README.md
+++ b/examples/node/README.md
@@ -29,6 +29,7 @@ SDK concept and uses current APIs.
 | [orchestrator](./orchestrator/)             | Orchestration             | Fan out sub-tasks to other agents, collect results |
 | [stock-sim](./stock-sim/)                   | Pipe streaming (provider) | Long-running stream of events                      |
 | [stock-sim-consumer](./stock-sim-consumer/) | Pipe streaming (consumer) | Submit pipe task, consume stream in real time      |
+| [chat-agent](./chat-agent/)                 | Multi-turn chat           | Conversation that remembers context across turns   |
 
 ## Advanced Examples
 

--- a/examples/node/bidi-chat/bidi-chat-consumer.ts
+++ b/examples/node/bidi-chat/bidi-chat-consumer.ts
@@ -32,7 +32,11 @@ if (!apiKey) {
 const cdmUrl = process.env.BLOCKS_CDM_URL;
 const baseUrl = process.env.BLOCKS_BACKEND_URL ?? (await fetchCdmConfig(cdmUrl)).api.baseUrl;
 
-const entry = await getAgent(AGENT_NAME, { baseUrl });
+// Pass the API key so the registry lookup is authenticated: the
+// GET /registry/agents route uses optionalAuth, so an anonymous lookup
+// only sees *public* agents. A freshly published agent is private to your
+// org and is invisible without the key.
+const entry = await getAgent(AGENT_NAME, { baseUrl, apiKey });
 if (!entry) {
   console.error(`Agent "${AGENT_NAME}" not found at ${baseUrl}.`);
   process.exit(1);

--- a/examples/node/chat-agent/README.md
+++ b/examples/node/chat-agent/README.md
@@ -1,0 +1,93 @@
+# chat-agent (Node)
+
+A multi-turn **chat agent that remembers context across turns** -- no LLM,
+no API key. It demonstrates the conversation pattern used by assistants like
+Claude Code: you send a message, the agent replies, you send another, and the
+earlier context is still there.
+
+**Category:** Canonical -- multi-turn / context retention
+
+## How it works
+
+Each turn is an independent `request` task. The Blocks wire protocol has no
+built-in conversation thread, so the agent carries one itself:
+
+1. On the **first turn** the consumer sends `{ "text": "..." }` with no id.
+2. The agent mints a `conversationId`, stores the conversation in memory, and
+   returns the id in its artifact.
+3. On **every following turn** the consumer includes that
+   `conversationId`, so the agent looks up the existing conversation and can
+   recall earlier messages.
+
+```
+[you]   hi, I'm Alice          -> { conversationId: "c-ab12cd", turn: 1 }
+[you]   what's my name?       (conversationId: "c-ab12cd") -> "You're Alice."
+[you]   what did I say first? (conversationId: "c-ab12cd") -> "Your first message was: hi, I'm Alice"
+```
+
+The reply logic is deterministic and exists only to prove context is kept:
+it captures your name from `"I'm <name>"`, recalls it on `"what's my name"`,
+replays turn 1 on `"what did I say first"`, and reports the turn count.
+
+> **In-memory caveat.** Conversation state lives in a `Map` in the agent
+> process, so the agent-card pins `concurrency: 1` and `expectedInstances: 1`.
+> A production chat agent would persist conversations in external storage
+> (Redis, a database, ...) keyed by `conversationId` so any instance can serve
+> any turn, and state survives restarts.
+
+## Prerequisites
+
+- Node.js 22+
+- `BLOCKS_API_KEY` in the project `.env`. Get it by running
+  `blocks login --write-env`.
+
+## Install
+
+```bash
+cd examples/node/chat-agent
+npm install
+```
+
+## Run
+
+In one terminal -- start the agent:
+
+```bash
+cd examples/node/chat-agent
+blocks publish   # first time only -- registers chat_agent_node
+blocks run
+```
+
+In another terminal -- run the consumer. With no arguments it starts an
+**interactive REPL**: type a message, read the reply, keep going. Type
+`exit` or `quit` (or press Ctrl-D) to end.
+
+```bash
+cd examples/node/chat-agent
+npx tsx chat-agent-consumer.ts
+# [you]   hi, I'm Alice
+# [agent] Nice to meet you, Alice.
+# [you]   what's my name?
+# [agent] You're Alice.
+# [you]   exit
+
+# or pass turns as arguments to run them non-interactively, then exit:
+npx tsx chat-agent-consumer.ts "I'm Sam" "what's my name?" "how many turns have we had?"
+```
+
+## SDK concepts demonstrated
+
+- Multi-turn conversation over independent `request` tasks
+- Application-level session threading via a `conversationId` round-tripped
+  through the artifact (the wire protocol has no conversation field)
+- Structured JSON input parsing from `task.requestParts`
+- Returning JSON artifacts with `mimeType: 'application/json'`
+- Consumer flow: `sendMessage` -> `onTerminal` -> `downloadArtifact`
+
+## What to edit
+
+- Change `composeReply()` in `handler.ts` to add new intents, or swap the
+  deterministic logic for a call to an LLM (pass the stored `state.turns` as
+  history).
+- Replace the in-memory `Map` with a Redis/DB lookup to make the agent
+  horizontally scalable.

--- a/examples/node/chat-agent/agent-card.json
+++ b/examples/node/chat-agent/agent-card.json
@@ -1,0 +1,62 @@
+{
+  "identity": {
+    "agentName": "chat_agent_node",
+    "displayName": "chat-agent (Node)",
+    "description": "Multi-turn chat agent that remembers context across turns. Each turn is an independent request task; the agent mints a conversationId on the first turn and returns it in the artifact so the consumer can thread it back into later turns.",
+    "version": "1.0.0",
+    "provider": {
+      "organization": "PubNub"
+    }
+  },
+  "capabilities": {
+    "taskKinds": ["request"]
+  },
+  "io": {
+    "inputs": [
+      {
+        "id": "message",
+        "description": "A chat message, plus an optional conversationId returned by a previous turn. Omit conversationId on the first turn.",
+        "contentType": "application/json",
+        "required": true,
+        "example": { "text": "hi, I'm Alice" },
+        "schema": {
+          "type": "object",
+          "required": ["text"],
+          "properties": {
+            "text": {
+              "type": "string",
+              "title": "Message",
+              "default": "hi, I'm Alice"
+            },
+            "conversationId": {
+              "type": "string",
+              "title": "Conversation ID",
+              "description": "Returned by the previous turn's artifact. Omit on the first turn."
+            }
+          }
+        }
+      }
+    ],
+    "outputs": [
+      {
+        "id": "reply",
+        "description": "Agent reply plus conversationId, turn number, and how many prior messages are remembered.",
+        "contentType": "application/json",
+        "guaranteed": true
+      }
+    ]
+  },
+  "tags": [
+    {
+      "id": "chat",
+      "name": "Multi-turn Chat",
+      "description": "Context-preserving conversation across independent request tasks."
+    }
+  ],
+  "runtime": {
+    "handler": "./handler.ts",
+    "handlerExport": "default",
+    "concurrency": 1,
+    "expectedInstances": 1
+  }
+}

--- a/examples/node/chat-agent/chat-agent-consumer.ts
+++ b/examples/node/chat-agent/chat-agent-consumer.ts
@@ -1,0 +1,156 @@
+/**
+ * chat-agent consumer (Node).
+ *
+ * An interactive multi-turn chat REPL against the chat-agent. You type a
+ * message, the agent replies, and the earlier context is still there on the
+ * next message. Each turn is a separate `request` task; the consumer reads the
+ * `conversationId` from the first turn's artifact and threads it into every
+ * following turn so the agent can recall earlier context.
+ *
+ * This is the consumer-side counterpart to the multi-turn pattern: the wire
+ * protocol has no conversation field, so the id is carried inside the request
+ * part's JSON `text` and echoed back in the artifact.
+ *
+ * Usage:
+ *   npx tsx chat-agent-consumer.ts                       # interactive REPL
+ *   npx tsx chat-agent-consumer.ts "I'm Sam" "what's my name?"  # scripted turns, then exit
+ *
+ * In the REPL, type `exit` or `quit` (or press Ctrl-D) to end the conversation.
+ *
+ * Environment variables:
+ *   BLOCKS_API_KEY      -- Blocks API key (required; run `blocks login --write-env`)
+ *   BLOCKS_BACKEND_URL  -- backend base URL (optional; defaults to CDM config)
+ *   BLOCKS_CDM_URL      -- CDM config URL (optional)
+ */
+
+import 'dotenv/config';
+import * as readline from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+import { TaskClient, fetchCdmConfig, getAgent } from '@blocks-network/sdk';
+
+const AGENT_NAME = 'chat_agent_node';
+
+const apiKey = process.env.BLOCKS_API_KEY;
+if (!apiKey) {
+  console.error('BLOCKS_API_KEY not set. Run `blocks login --write-env` first.');
+  process.exit(1);
+}
+
+const cdmUrl = process.env.BLOCKS_CDM_URL;
+const baseUrl = process.env.BLOCKS_BACKEND_URL ?? (await fetchCdmConfig(cdmUrl)).api.baseUrl;
+
+// Pass the API key so the registry lookup is authenticated: the
+// GET /registry/agents route uses optionalAuth, so an anonymous lookup
+// only sees *public* agents. A freshly published agent is private to your
+// org and is invisible without the key.
+const entry = await getAgent(AGENT_NAME, { baseUrl, apiKey });
+if (!entry) {
+  console.error(`Agent "${AGENT_NAME}" not found at ${baseUrl}. Run \`blocks publish\` in this folder first.`);
+  process.exit(1);
+}
+const billingMode = entry.billingMode ?? 'free';
+
+const client = await TaskClient.create({ billingMode, apiKey, cdmUrl, baseUrl });
+
+async function sendTurn(text: string, conversationId: string | null): Promise<{
+  reply: string;
+  conversationId: string;
+  turn: number;
+}> {
+  const message: Record<string, unknown> = { text };
+  if (conversationId) message.conversationId = conversationId;
+
+  const session = await client.sendMessage({
+    agentName: AGENT_NAME,
+    requestParts: [{ partId: 'message', text: JSON.stringify(message), contentType: 'application/json' }],
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      session.close();
+      reject(new Error('Timed out waiting for terminal after 30s'));
+    }, 30_000);
+    session.onTerminal(() => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
+
+  const refs = session.listArtifacts();
+  if (refs.length === 0) {
+    session.close();
+    throw new Error('Agent returned no artifact.');
+  }
+  const downloaded = await session.downloadArtifact(refs[0]);
+  const parsed = JSON.parse(new TextDecoder().decode(downloaded.data));
+  session.close();
+
+  return { reply: parsed.reply, conversationId: parsed.conversationId, turn: parsed.turn };
+}
+
+function isExit(text: string): boolean {
+  const t = text.trim().toLowerCase();
+  return t === 'exit' || t === 'quit';
+}
+
+let conversationId: string | null = null;
+let turnsSent = 0;
+
+async function say(text: string): Promise<void> {
+  const result = await sendTurn(text, conversationId);
+  conversationId = result.conversationId;
+  turnsSent = result.turn;
+  console.log(`[agent] ${result.reply}`);
+  console.log(`        (conversationId=${result.conversationId}, turn=${result.turn})`);
+}
+
+async function runScripted(turns: string[]): Promise<void> {
+  for (const text of turns) {
+    console.log(`\n[you]   ${text}`);
+    await say(text);
+  }
+}
+
+async function runInteractive(): Promise<void> {
+  console.log('Interactive chat with the agent. Type `exit` or `quit` (or Ctrl-D) to end.\n');
+  const rl = readline.createInterface({ input, output });
+  try {
+    while (true) {
+      let text: string;
+      try {
+        text = await rl.question('[you]   ');
+      } catch {
+        break; // Ctrl-D / stream closed
+      }
+      if (text.trim() === '') continue;
+      if (isExit(text)) break;
+      await say(text);
+      console.log('');
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length > 0) {
+    await runScripted(args);
+  } else {
+    await runInteractive();
+  }
+
+  console.log(
+    turnsSent > 1
+      ? '\nConversation complete. The agent recalled context from earlier turns.'
+      : '\nConversation complete.',
+  );
+  client.destroy();
+}
+
+main().catch((err) => {
+  console.error(err);
+  client.destroy();
+  process.exit(1);
+});

--- a/examples/node/chat-agent/handler.ts
+++ b/examples/node/chat-agent/handler.ts
@@ -1,0 +1,185 @@
+import type { StartTaskMessage, TaskContext, HandlerResult } from '@blocks-network/sdk';
+
+/**
+ * Multi-turn chat handler with context retention -- no LLM, no API key.
+ *
+ * Each turn is an independent `request` task. Conversation state is kept in
+ * an in-process Map keyed by a `conversationId` that the agent mints on the
+ * first turn and returns in its artifact. The consumer threads that id back
+ * into every following turn, so context is preserved across tasks even though
+ * the wire protocol has no built-in notion of a conversation.
+ *
+ * Input (first turn):
+ *   { "text": "hi, I'm Alice" }
+ * Input (follow-up turn):
+ *   { "text": "what's my name?", "conversationId": "c-ab12cd" }
+ *
+ * Output artifact (application/json):
+ *   { "ok": true, "reply": "...", "conversationId": "c-ab12cd", "turn": 2, "remembered": 1 }
+ *
+ * The replies are deterministic and exist only to *prove* that earlier turns
+ * are remembered:
+ *   - "I'm X" / "my name is X"   -> stores the name
+ *   - "what's my name"           -> recalls the stored name
+ *   - "what did I say first"     -> replays turn 1
+ *   - anything else              -> acknowledges and reports turn/history counts
+ *
+ * NOTE: state lives in memory, so the agent-card pins concurrency: 1 and
+ * expectedInstances: 1. A production chat agent would persist conversations in
+ * external storage (Redis, a database, ...) keyed by `conversationId` so any
+ * instance can serve any turn.
+ */
+
+interface ConversationState {
+  turns: string[];
+  name?: string;
+}
+
+const conversations = new Map<string, ConversationState>();
+
+export default async function handler(
+  task: StartTaskMessage,
+  ctx?: TaskContext,
+): Promise<HandlerResult> {
+  const { text, conversationId: incomingId } = extractInput(task.requestParts ?? []);
+
+  if (text === null) {
+    throw new Error('Missing request part with a "text" field. Send { "text": "<message>", "conversationId": "<optional id>" }');
+  }
+
+  // Resume an existing conversation, or start a fresh one. An unknown id is
+  // treated as a new conversation (state may have been lost on restart).
+  const conversationId =
+    incomingId && conversations.has(incomingId) ? incomingId : newConversationId(task.taskId);
+
+  const state = conversations.get(conversationId) ?? { turns: [] };
+  conversations.set(conversationId, state);
+
+  state.turns.push(text);
+  const capturedName = extractName(text);
+  if (capturedName) {
+    state.name = capturedName;
+  }
+
+  ctx?.reportStatus(`Turn ${state.turns.length} of conversation ${conversationId}`);
+
+  const reply = composeReply(text, state);
+
+  const payload = {
+    ok: true,
+    reply,
+    conversationId,
+    turn: state.turns.length,
+    // prior messages remembered from earlier turns (excludes the current one)
+    remembered: state.turns.length - 1,
+  };
+
+  return {
+    artifacts: [{ data: JSON.stringify(payload, null, 2), mimeType: 'application/json' }],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic reply engine
+// ---------------------------------------------------------------------------
+
+function composeReply(text: string, state: ConversationState): string {
+  const normalized = text.trim().toLowerCase();
+
+  if (/\b(what(?:'s| is| was)? my name|who am i)\b/.test(normalized)) {
+    return state.name
+      ? `You're ${state.name}.`
+      : "I don't know your name yet -- tell me with \"I'm <name>\".";
+  }
+
+  if (/\bwhat did i say first\b/.test(normalized) || /\bmy first (message|line)\b/.test(normalized)) {
+    return `Your first message was: "${state.turns[0]}"`;
+  }
+
+  if (/\bhow many (messages|turns)\b/.test(normalized)) {
+    return `We're on turn ${state.turns.length}; I remember all ${state.turns.length} of your messages.`;
+  }
+
+  const capturedName = extractName(text);
+  if (capturedName) {
+    return `Nice to meet you, ${capturedName}! I'll remember that. (turn ${state.turns.length})`;
+  }
+
+  const prefix = state.name ? `${state.name}, you said` : 'You said';
+  return `${prefix}: "${text}". That's turn ${state.turns.length} -- I've kept the whole conversation.`;
+}
+
+// Demo-grade name capture: greedy enough that phrasings like "I'm fine" or
+// "call me later" would otherwise be read as names. A small stop-word set
+// guards the common false positives; a real agent would use an NLU model.
+const NAME_STOP_WORDS = new Set([
+  'fine', 'done', 'sorry', 'back', 'here', 'ok', 'okay', 'good', 'great',
+  'later', 'now', 'sure', 'right',
+]);
+
+function extractName(text: string): string | undefined {
+  const match =
+    /\b(?:i'm|i am|my name is|call me)\s+([a-z][a-z'.-]*)/i.exec(text);
+  if (!match) return undefined;
+  const raw = match[1];
+  if (NAME_STOP_WORDS.has(raw.toLowerCase())) return undefined;
+  return raw.charAt(0).toUpperCase() + raw.slice(1);
+}
+
+// ---------------------------------------------------------------------------
+// Input parsing helpers
+// ---------------------------------------------------------------------------
+
+interface ExtractedInput {
+  text: string | null;
+  conversationId: string | null;
+}
+
+function extractInput(parts: unknown[]): ExtractedInput {
+  let text: string | null = null;
+  let conversationId: string | null = null;
+
+  for (const part of parts) {
+    if (typeof part === 'string') {
+      text = part;
+      continue;
+    }
+    if (!isRecord(part)) continue;
+    const content = parsePartContent(part);
+    if (typeof content.text === 'string') {
+      text = content.text;
+    }
+    if (typeof content.conversationId === 'string') {
+      conversationId = content.conversationId;
+    }
+  }
+
+  return { text, conversationId };
+}
+
+function parsePartContent(part: Record<string, unknown>): Record<string, unknown> {
+  if (typeof part.text === 'string') {
+    try {
+      const parsed = JSON.parse(part.text);
+      if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // text is a plain string, not JSON -- fall through and use the part as-is
+    }
+  }
+  return part;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+// A short, human-readable id derived from the task id. Deterministic so the
+// example needs no Math.random(); collisions across conversations are
+// vanishingly unlikely because each first turn has a distinct taskId (only
+// the first 6 hex chars are kept, so uniqueness is probabilistic, not exact).
+function newConversationId(taskId: string | undefined): string {
+  const suffix = (taskId ?? 'conv').replace(/[^a-z0-9]/gi, '').slice(0, 6).toLowerCase();
+  return `c-${suffix || 'start'}`;
+}

--- a/examples/node/chat-agent/package.json
+++ b/examples/node/chat-agent/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "chat-agent",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "start": "blocks run",
+    "check": "blocks check"
+  },
+  "dependencies": {
+    "@blocks-network/sdk": "*",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -29,6 +29,7 @@ SDK concept and uses current APIs.
 | [orchestrator](./orchestrator/)             | Orchestration             | Fan out sub-tasks to other agents, collect results |
 | [stock-sim](./stock-sim/)                   | Pipe streaming (provider) | Long-running stream of events                      |
 | [stock-sim-consumer](./stock-sim-consumer/) | Pipe streaming (consumer) | Submit pipe task, consume stream in real time      |
+| [chat-agent](./chat-agent/)                 | Multi-turn chat           | Conversation that remembers context across turns   |
 
 ## Advanced Examples
 

--- a/examples/python/chat-agent/README.md
+++ b/examples/python/chat-agent/README.md
@@ -1,0 +1,93 @@
+# chat-agent (Python)
+
+A multi-turn **chat agent that remembers context across turns** -- no LLM,
+no API key. It demonstrates the conversation pattern used by assistants like
+Claude Code: you send a message, the agent replies, you send another, and the
+earlier context is still there.
+
+**Category:** Canonical -- multi-turn / context retention
+
+## How it works
+
+Each turn is an independent `request` task. The Blocks wire protocol has no
+built-in conversation thread, so the agent carries one itself:
+
+1. On the **first turn** the consumer sends `{ "text": "..." }` with no id.
+2. The agent mints a `conversationId`, stores the conversation in memory, and
+   returns the id in its artifact.
+3. On **every following turn** the consumer includes that
+   `conversationId`, so the agent looks up the existing conversation and can
+   recall earlier messages.
+
+```
+[you]   hi, I'm Alice          -> { conversationId: "c-ab12cd", turn: 1 }
+[you]   what's my name?       (conversationId: "c-ab12cd") -> "You're Alice."
+[you]   what did I say first? (conversationId: "c-ab12cd") -> "Your first message was: hi, I'm Alice"
+```
+
+The reply logic is deterministic and exists only to prove context is kept:
+it captures your name from `"I'm <name>"`, recalls it on `"what's my name"`,
+replays turn 1 on `"what did I say first"`, and reports the turn count.
+
+> **In-memory caveat.** Conversation state lives in a dict in the agent
+> process, so the agent-card pins `concurrency: 1` and `expectedInstances: 1`.
+> A production chat agent would persist conversations in external storage
+> (Redis, a database, ...) keyed by `conversationId` so any instance can serve
+> any turn, and state survives restarts.
+
+## Prerequisites
+
+- Python 3.10+
+- `BLOCKS_API_KEY` in the project `.env`. Get it by running
+  `blocks login --write-env`.
+
+## Install
+
+```bash
+cd examples/python/chat-agent
+pip install -e .
+```
+
+## Run
+
+In one terminal -- start the agent:
+
+```bash
+cd examples/python/chat-agent
+blocks publish   # first time only -- registers chat_agent_python
+blocks run
+```
+
+In another terminal -- run the consumer. With no arguments it starts an
+**interactive REPL**: type a message, read the reply, keep going. Type
+`exit` or `quit` (or press Ctrl-D) to end.
+
+```bash
+cd examples/python/chat-agent
+python main.py
+# [you]   hi, I'm Alice
+# [agent] Nice to meet you, Alice.
+# [you]   what's my name?
+# [agent] You're Alice.
+# [you]   exit
+
+# or pass turns as arguments to run them non-interactively, then exit:
+python main.py "I'm Sam" "what's my name?" "how many turns have we had?"
+```
+
+## SDK concepts demonstrated
+
+- Multi-turn conversation over independent `request` tasks
+- Application-level session threading via a `conversationId` round-tripped
+  through the artifact (the wire protocol has no conversation field)
+- Structured JSON input parsing from `task.request_parts`
+- Returning JSON artifacts with `mimeType: 'application/json'`
+- Consumer flow: `send_message` -> `wait_for_terminal` -> `download_artifact`
+
+## What to edit
+
+- Change `_compose_reply()` in `handler.py` to add new intents, or swap the
+  deterministic logic for a call to an LLM (pass the stored `state["turns"]`
+  as history).
+- Replace the in-memory dict with a Redis/DB lookup to make the agent
+  horizontally scalable.

--- a/examples/python/chat-agent/agent-card.json
+++ b/examples/python/chat-agent/agent-card.json
@@ -1,0 +1,62 @@
+{
+  "identity": {
+    "agentName": "chat_agent_python",
+    "displayName": "chat-agent (Python)",
+    "description": "Multi-turn chat agent that remembers context across turns. Each turn is an independent request task; the agent mints a conversationId on the first turn and returns it in the artifact so the consumer can thread it back into later turns.",
+    "version": "1.0.0",
+    "provider": {
+      "organization": "PubNub"
+    }
+  },
+  "capabilities": {
+    "taskKinds": ["request"]
+  },
+  "io": {
+    "inputs": [
+      {
+        "id": "message",
+        "description": "A chat message, plus an optional conversationId returned by a previous turn. Omit conversationId on the first turn.",
+        "contentType": "application/json",
+        "required": true,
+        "example": { "text": "hi, I'm Alice" },
+        "schema": {
+          "type": "object",
+          "required": ["text"],
+          "properties": {
+            "text": {
+              "type": "string",
+              "title": "Message",
+              "default": "hi, I'm Alice"
+            },
+            "conversationId": {
+              "type": "string",
+              "title": "Conversation ID",
+              "description": "Returned by the previous turn's artifact. Omit on the first turn."
+            }
+          }
+        }
+      }
+    ],
+    "outputs": [
+      {
+        "id": "reply",
+        "description": "Agent reply plus conversationId, turn number, and how many prior messages are remembered.",
+        "contentType": "application/json",
+        "guaranteed": true
+      }
+    ]
+  },
+  "tags": [
+    {
+      "id": "chat",
+      "name": "Multi-turn Chat",
+      "description": "Context-preserving conversation across independent request tasks."
+    }
+  ],
+  "runtime": {
+    "handler": "./handler.py",
+    "handlerExport": "handler",
+    "concurrency": 1,
+    "expectedInstances": 1
+  }
+}

--- a/examples/python/chat-agent/handler.py
+++ b/examples/python/chat-agent/handler.py
@@ -1,0 +1,190 @@
+"""Multi-turn chat handler with context retention -- no LLM, no API key.
+
+Mirrors the Node chat-agent example handler.
+
+Each turn is an independent ``request`` task. Conversation state is kept in an
+in-process dict keyed by a ``conversationId`` that the agent mints on the first
+turn and returns in its artifact. The consumer threads that id back into every
+following turn, so context is preserved across tasks even though the wire
+protocol has no built-in notion of a conversation.
+
+Input (first turn):
+    { "text": "hi, I'm Alice" }
+Input (follow-up turn):
+    { "text": "what's my name?", "conversationId": "c-ab12cd" }
+
+Output artifact (application/json):
+    { "ok": true, "reply": "...", "conversationId": "c-ab12cd", "turn": 2, "remembered": 1 }
+
+The replies are deterministic and exist only to *prove* that earlier turns are
+remembered:
+    - "I'm X" / "my name is X"   -> stores the name
+    - "what's my name"           -> recalls the stored name
+    - "what did I say first"     -> replays turn 1
+    - anything else              -> acknowledges and reports turn/history counts
+
+NOTE: state lives in memory, so the agent-card pins concurrency: 1 and
+expectedInstances: 1. A production chat agent would persist conversations in
+external storage (Redis, a database, ...) keyed by ``conversationId`` so any
+instance can serve any turn.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from blocks_network.types import StartTaskMessage, TaskContext
+
+# conversationId -> {"turns": [...], "name": Optional[str]}
+_conversations: Dict[str, Dict[str, Any]] = {}
+
+_NAME_RE = re.compile(r"\b(?:i'm|i am|my name is|call me)\s+([a-z][a-z'.-]*)", re.IGNORECASE)
+# Demo-grade name capture: greedy enough that phrasings like "I'm fine" or
+# "call me later" would otherwise be read as names. A small stop-word set guards
+# the common false positives; a real agent would use an NLU model.
+_NAME_STOP_WORDS = frozenset(
+    {"fine", "done", "sorry", "back", "here", "ok", "okay", "good", "great", "later", "now", "sure", "right"}
+)
+_ASK_NAME_RE = re.compile(r"\b(what(?:'s| is| was)? my name|who am i)\b")
+_FIRST_RE = re.compile(r"\bwhat did i say first\b|\bmy first (?:message|line)\b")
+_COUNT_RE = re.compile(r"\bhow many (?:messages|turns)\b")
+
+
+def handler(task: StartTaskMessage, ctx: Optional[TaskContext] = None) -> Dict[str, Any]:
+    text, incoming_id = _extract_input(task.request_parts or [])
+
+    if text is None:
+        raise ValueError(
+            'Missing request part with a "text" field. '
+            'Send { "text": "<message>", "conversationId": "<optional id>" }'
+        )
+
+    # Resume an existing conversation, or start a fresh one. An unknown id is
+    # treated as a new conversation (state may have been lost on restart).
+    if incoming_id and incoming_id in _conversations:
+        conversation_id = incoming_id
+    else:
+        conversation_id = _new_conversation_id(task.task_id)
+
+    state = _conversations.setdefault(conversation_id, {"turns": [], "name": None})
+
+    state["turns"].append(text)
+    captured = _extract_name(text)
+    if captured:
+        state["name"] = captured
+
+    if ctx:
+        ctx.report_status(f"Turn {len(state['turns'])} of conversation {conversation_id}")
+
+    reply = _compose_reply(text, state)
+
+    payload = {
+        "ok": True,
+        "reply": reply,
+        "conversationId": conversation_id,
+        "turn": len(state["turns"]),
+        # prior messages remembered from earlier turns (excludes the current one)
+        "remembered": len(state["turns"]) - 1,
+    }
+
+    return {
+        "artifacts": [{"data": json.dumps(payload, indent=2), "mimeType": "application/json"}],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Deterministic reply engine
+# ---------------------------------------------------------------------------
+
+
+def _compose_reply(text: str, state: Dict[str, Any]) -> str:
+    normalized = text.strip().lower()
+    turns: List[str] = state["turns"]
+    name: Optional[str] = state["name"]
+
+    if _ASK_NAME_RE.search(normalized):
+        if name:
+            return f"You're {name}."
+        return "I don't know your name yet -- tell me with \"I'm <name>\"."
+
+    if _FIRST_RE.search(normalized):
+        return f'Your first message was: "{turns[0]}"'
+
+    if _COUNT_RE.search(normalized):
+        return f"We're on turn {len(turns)}; I remember all {len(turns)} of your messages."
+
+    captured = _extract_name(text)
+    if captured:
+        return f"Nice to meet you, {captured}! I'll remember that. (turn {len(turns)})"
+
+    prefix = f"{name}, you said" if name else "You said"
+    return f'{prefix}: "{text}". That\'s turn {len(turns)} -- I\'ve kept the whole conversation.'
+
+
+def _extract_name(text: str) -> Optional[str]:
+    match = _NAME_RE.search(text)
+    if not match:
+        return None
+    raw = match.group(1)
+    if raw.lower() in _NAME_STOP_WORDS:
+        return None
+    return raw[0].upper() + raw[1:]
+
+
+# ---------------------------------------------------------------------------
+# Input parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_input(parts: List[Any]) -> Tuple[Optional[str], Optional[str]]:
+    text: Optional[str] = None
+    conversation_id: Optional[str] = None
+
+    for part in parts:
+        if isinstance(part, str):
+            text = part
+            continue
+        content = _parse_part_content(part)
+        if isinstance(content.get("text"), str):
+            text = content["text"]
+        if isinstance(content.get("conversationId"), str):
+            conversation_id = content["conversationId"]
+
+    return text, conversation_id
+
+
+def _parse_part_content(part: Any) -> Dict[str, Any]:
+    """Extract structured content from a RequestPart or raw dict.
+
+    The consumer serializes the message + conversationId into the ``text``
+    field as JSON. This helper parses it back into a dict, falling back to a
+    plain-text wrapper or the part's own ``extra``/dict form.
+    """
+    text = getattr(part, "text", None) if not isinstance(part, dict) else part.get("text")
+    if isinstance(text, str):
+        try:
+            parsed = json.loads(text)
+            if isinstance(parsed, dict):
+                return parsed
+        except (json.JSONDecodeError, ValueError):
+            pass
+        return {"text": text}
+    if hasattr(part, "extra") and isinstance(part.extra, dict):
+        return part.extra
+    if isinstance(part, dict):
+        return part
+    return {}
+
+
+def _new_conversation_id(task_id: Optional[str]) -> str:
+    """A short, human-readable id derived from the task id.
+
+    Deterministic so the example needs no randomness; collisions across
+    conversations are vanishingly unlikely because each first turn has a
+    distinct task_id (only the first 6 hex chars are kept, so uniqueness is
+    probabilistic, not exact).
+    """
+    suffix = re.sub(r"[^a-z0-9]", "", (task_id or "conv"), flags=re.IGNORECASE)[:6].lower()
+    return f"c-{suffix or 'start'}"

--- a/examples/python/chat-agent/main.py
+++ b/examples/python/chat-agent/main.py
@@ -1,0 +1,143 @@
+"""chat-agent consumer (Python).
+
+An interactive multi-turn chat REPL against the chat-agent. You type a message,
+the agent replies, and the earlier context is still there on the next message.
+Each turn is a separate ``request`` task; the consumer reads the
+``conversationId`` from the first turn's artifact and threads it into every
+following turn so the agent can recall earlier context.
+
+The wire protocol has no conversation field, so the id is carried inside the
+request part's JSON ``text`` and echoed back in the artifact.
+
+Usage:
+    python main.py                              # interactive REPL
+    python main.py "I'm Sam" "what's my name?"  # scripted turns, then exit
+
+In the REPL, type ``exit`` or ``quit`` (or press Ctrl-D) to end the conversation.
+
+Environment variables:
+    BLOCKS_API_KEY      -- Blocks API key (required; run `blocks login --write-env`)
+    BLOCKS_BACKEND_URL  -- backend base URL (optional; defaults to CDM config)
+    BLOCKS_CDM_URL      -- CDM config URL (optional)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Optional, Tuple
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from blocks_network import TaskClient, fetch_cdm_config
+from blocks_network.agent_registry import get_agent
+
+AGENT_NAME = "chat_agent_python"
+
+
+def main() -> None:
+    api_key = os.environ.get("BLOCKS_API_KEY")
+    if not api_key:
+        print("BLOCKS_API_KEY not set. Run 'blocks login --write-env' first.", file=sys.stderr)
+        sys.exit(1)
+
+    cdm_url = os.environ.get("BLOCKS_CDM_URL")
+    base_url = os.environ.get("BLOCKS_BACKEND_URL") or fetch_cdm_config(cdm_url).api.base_url
+
+    entry = get_agent(AGENT_NAME, base_url=base_url, api_key=api_key)
+    if entry is None:
+        print(
+            f"Agent '{AGENT_NAME}' not found at {base_url}. "
+            "Run 'blocks publish' in this folder first.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    billing_mode = entry.billing_mode or "free"
+
+    client = TaskClient.create(
+        billing_mode=billing_mode,
+        api_key=api_key,
+        base_url=base_url,
+        cdm_url=cdm_url,
+    )
+
+    def send_turn(text: str, conversation_id: Optional[str]) -> Tuple[str, str, int]:
+        message = {"text": text}
+        if conversation_id:
+            message["conversationId"] = conversation_id
+
+        session = client.send_message(
+            agent_name=AGENT_NAME,
+            request_parts=[
+                {
+                    "partId": "message",
+                    "text": json.dumps(message),
+                    "contentType": "application/json",
+                }
+            ],
+        )
+
+        try:
+            session.wait_for_terminal(timeout=30)
+        except TimeoutError:
+            session.close()
+            raise RuntimeError("Timed out waiting for terminal event.")
+
+        refs = session.list_artifacts()
+        if not refs:
+            session.close()
+            raise RuntimeError("Agent returned no artifact.")
+        downloaded = session.download_artifact(refs[0])
+        parsed = json.loads(downloaded.data.decode("utf-8"))
+        session.close()
+        return parsed["reply"], parsed["conversationId"], parsed["turn"]
+
+    conversation_id: Optional[str] = None
+    turns_sent = 0
+
+    def say(text: str) -> None:
+        nonlocal conversation_id, turns_sent
+        reply, conversation_id, turn = send_turn(text, conversation_id)
+        turns_sent = turn
+        print(f"[agent] {reply}")
+        print(f"        (conversationId={conversation_id}, turn={turn})")
+
+    def run_scripted(turns: list[str]) -> None:
+        for text in turns:
+            print(f"\n[you]   {text}")
+            say(text)
+
+    def run_interactive() -> None:
+        print("Interactive chat with the agent. Type 'exit' or 'quit' (or Ctrl-D) to end.\n")
+        while True:
+            try:
+                text = input("[you]   ")
+            except EOFError:
+                break
+            if text.strip() == "":
+                continue
+            if text.strip().lower() in ("exit", "quit"):
+                break
+            say(text)
+            print("")
+
+    args = sys.argv[1:]
+    try:
+        if args:
+            run_scripted(args)
+        else:
+            run_interactive()
+    finally:
+        client.destroy()
+
+    if turns_sent > 1:
+        print("\nConversation complete. The agent recalled context from earlier turns.")
+    else:
+        print("\nConversation complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/chat-agent/pyproject.toml
+++ b/examples/python/chat-agent/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "chat-agent-example"
+version = "1.0.0"
+description = "Multi-turn chat agent example for Blocks Network"
+requires-python = ">=3.10"
+dependencies = [
+    "blocks-network",
+    "python-dotenv>=1.0.0",
+]
+
+[tool.setuptools]
+py-modules = ["handler", "main"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -879,6 +879,16 @@
         "text-encoding": "^0.7.0"
       }
     },
+    "examples/node/chat-agent": {
+      "version": "1.0.0",
+      "dependencies": {
+        "@blocks-network/sdk": "*",
+        "dotenv": "^16.4.5"
+      },
+      "devDependencies": {
+        "typescript": "^5.4.5"
+      }
+    },
     "examples/node/claude-code": {
       "name": "claude-code-node",
       "version": "1.0.0",
@@ -3917,6 +3927,10 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/chat-agent": {
+      "resolved": "examples/node/chat-agent",
+      "link": true
     },
     "node_modules/check-error": {
       "version": "2.1.3",


### PR DESCRIPTION
## Node SDK & Python SDK

### Added
- A new multi-turn chat-agent example is available for both Node and Python, showing how to build a conversational agent.
