### PR TITLE
Node SDK & Python SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Each component (Node SDK, Python SDK, CLI) is versioned independently.
   instead of `{providerAgentName}-stream-NNNN`. Provider-side and server-side
   semantics are unchanged.
 - `InboundMessage` is now a discriminated union keyed by `format`: `data` is typed `string[]` for `bytes`, `unknown[]` for `events`, and `Record<string, unknown>` for `raw`. Still exported from `@blocks-network/sdk` and from the dedicated `@blocks-network/sdk/stream` subpath. Prefer `stream.events()` / `stream.bytes()` for application code; `stream.inbound` is the advanced/raw path.
+- The "Agent not found in registry" error thrown when starting an unregistered agent now points to `blocks register` (private + free, recommended) before `blocks publish` (public/paid), so the suggested fix matches the recommended onboarding flow.
 
 #### Removed
 - The `onRetry` option on `PubNubClientConfig` (advanced-usage `createPubNubClient`). Connectivity activity is now surfaced automatically through structured log events: `transport_degraded` (warn) on entering a degraded state, `transport_restored` (info) on recovery. **Migration:** drop the `onRetry` option from `createPubNubClient(...)` calls and read the structured log stream instead.
@@ -117,6 +118,7 @@ consumer-side task submission, real-time event subscriptions, streaming
   instead of `{providerAgentName}-stream-NNNN`. Provider-side and server-side
   semantics are unchanged.
 - `InboundMessage` docstring now documents the per-format runtime shape of `data` (`list[str]` for `bytes`, `list[Any]` for `events`, `dict[str, Any]` for `raw`) so consumers don't treat it as a single value.
+- The "Agent not found in registry" error raised when starting an unregistered agent now points to `blocks register` (private + free, recommended) before `blocks publish` (public/paid), so the suggested fix matches the recommended onboarding flow.
 
 #### Security
 - PAM token isolation from handler-visible task objects

--- a/sdks/node/src/runtime/agent-instance.ts
+++ b/sdks/node/src/runtime/agent-instance.ts
@@ -579,7 +579,8 @@ export const startAgentInstance = async (
     if (!agentEntry) {
       throw new Error(
         `[AgentInstance] Agent "${agentName}" not found in registry. ` +
-          'Register the agent (e.g. via `blocks publish`) before starting an instance.',
+          'Register the agent first — `blocks register` (private + free, recommended) ' +
+          'or `blocks publish` (public/paid) — before starting an instance.',
       );
     }
     if (!agentEntry.billingMode) {

--- a/sdks/python/blocks_network/agent_instance.py
+++ b/sdks/python/blocks_network/agent_instance.py
@@ -452,7 +452,9 @@ def start_agent_instance(
                 f'Agent "{agent_name}" not found in registry. '
                 f"start_agent_instance requires a registered agent so the "
                 f"SDK can resolve billing_mode authoritatively from the "
-                f"registry GET. Run 'blocks publish' first."
+                f"registry GET. Register the agent first — "
+                f"`blocks register` (private + free, recommended) or "
+                f"`blocks publish` (public/paid) — before starting an instance."
             )
         if agent_entry.billing_mode not in ("free", "paid"):
             # Fail fast rather than guessing from price fields or keyset

--- a/skills/GETSTARTED.md
+++ b/skills/GETSTARTED.md
@@ -240,8 +240,8 @@ blocks publish --billing-mode paid --listing private \
 ```
 
 For the full non-interactive flag table, paid-pricing variants, and
-private-agent invite management, see `https://config.blocks.ai/SKILL.md` → Publishing &
-Republishing.
+private-agent invite management, see `https://config.blocks.ai/SKILL.md` → Registering &
+Publishing.
 
 **Name conflict.** If the user reports that `blocks register` or
 `blocks publish` rejected the name as taken, ask for a more unique
@@ -325,8 +325,8 @@ Now that the agent is published and running, hand off to the
 
 - **Streaming output** -- `https://config.blocks.ai/SKILL.md` → Streaming Agents
 - **Calling agents from scripts/apps** -- `https://config.blocks.ai/SKILL.md` → Consumer Projects & Trigger / Client Code
-- **Modifying or republishing** -- `https://config.blocks.ai/SKILL.md` → Modifying an Existing Agent / Publishing & Republishing
-- **Private-agent access** -- `https://config.blocks.ai/SKILL.md` → Publishing & Republishing → invite management
+- **Modifying or republishing** -- `https://config.blocks.ai/SKILL.md` → Modifying an Existing Agent / Registering & Publishing
+- **Private-agent access** -- `https://config.blocks.ai/SKILL.md` → Registering & Publishing → invite management
 - **Troubleshooting** -- `https://config.blocks.ai/SKILL.md` → Common Pitfalls
 - **CLI commands** (`whoami`, `logout`, `version`, env-var overrides) -- `https://config.blocks.ai/SKILL.md` → CLI Reference
 

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   author: blocks-network
   version: "0.3.0"
   domain: real-time
-  triggers: blocks, blocks-network, agent, a2a, modify agent, update agent, change agent, fix agent, edit agent, deploy agent, connect agent, register agent, publish agent, republish, streaming agent, consumer, consume agent, call agent, task client, taskclient, trigger script, invite, private agent, agent card, io schema, runtime config, blocks cli, troubleshoot, pitfall, blocks login, blocks publish, blocks check, blocks dashboard
+  triggers: blocks, blocks-network, agent, a2a, modify agent, update agent, change agent, fix agent, edit agent, deploy agent, connect agent, register agent, publish agent, republish, streaming agent, consumer, consume agent, call agent, task client, taskclient, trigger script, invite, private agent, agent card, io schema, runtime config, blocks cli, troubleshoot, pitfall, blocks login, blocks register, blocks publish, blocks check, blocks dashboard
   role: specialist
   scope: implementation
   output-format: code
@@ -26,7 +26,7 @@ flags, troubleshooting.
 
 Execute every command directly using the Bash tool. Never ask the user
 to run commands themselves except where this skill explicitly says to
-(e.g. `blocks publish`, `blocks run`).
+(e.g. `blocks register`, `blocks publish`, `blocks run`).
 
 **Language:** Default to **Node (TypeScript)**. Only use Python if the
 user explicitly requests it. For Python, see [Python Reference].
@@ -62,7 +62,7 @@ guidance) and [IO Schema Reference] (input/output rules).
 - [Agent Card Reference](#agent-card-reference) -- runtime config, optional fields
 - [IO Schema Rules](#io-schema-rules) -- transport classes, examples, drafting from a handler
 - [Streaming Agents](#streaming-agents) -- direction/format matrix, handler I/O, consumer I/O
-- [Publishing & Republishing](#publishing--republishing) -- non-interactive flags, name conflicts, invite management
+- [Registering & Publishing](#registering--publishing) -- register private/free first, promote to public/paid later, non-interactive flags, name conflicts, invite management
 - [Modifying an Existing Agent](#modifying-an-existing-agent) -- edit-and-republish recipe
 - [Deploying Code You've Already Written](#deploying-code-youve-already-written) -- locate, draft missing card, publish
 - [Consumer Projects & Trigger / Client Code](#consumer-projects--trigger--client-code) -- calling agents from scripts/apps
@@ -407,11 +407,20 @@ reconstruction after `connect()`, use `session.listEvents()` /
 history; this history list is not populated for new `sendMessage()` /
 `send_message()` sessions.
 
-## Publishing & Republishing
+## Registering & Publishing
 
-Publishing pushes the latest IO schemas, streaming capabilities, and
-description to the registry. Republish whenever the agent card or
-handler shape changes.
+Registering / publishing pushes the latest IO schemas, streaming
+capabilities, and description to the registry. Re-register (or
+republish) whenever the agent card or handler shape changes — running
+`blocks register` again on the same agent updates the card, IO schema,
+description, and tags the same way re-running `blocks publish` does.
+
+**Caveat once you've promoted with `blocks publish`:** `blocks register`
+always sends `listing=private` + `billingMode=free`, so re-running it
+on an agent that was promoted to public/paid will reset the visibility
+and pricing back to private+free (card content still updates
+correctly). After the first promotion, prefer `blocks publish` for
+subsequent updates so the listing isn't silently demoted.
 
 The recommended first step is `blocks register`, which registers the
 agent **privately and free** (usable by the owner and invited
@@ -469,12 +478,15 @@ blocks publish --billing-mode paid --listing private \
 
 ### Name conflicts
 
-Agent names are globally unique across the Blocks Network. If the user
-reports that `blocks publish` rejected the name as duplicate / already
-taken, inform them that the name is unavailable and ask for a more
-unique alternative via the host question tool. Update
-`agent-card.json` `identity.agentName` (and rename the project
-directory if needed), then ask the user to re-run `blocks publish`.
+Agent names are globally unique across the Blocks Network. Since
+`blocks register` is the recommended first step, name collisions
+typically surface there; `blocks publish` enforces the same check. If
+either command rejected the name as duplicate / already taken, inform
+the user that the name is unavailable and ask for a more unique
+alternative via the host question tool. Update `agent-card.json`
+`identity.agentName` (and rename the project directory if needed),
+then ask the user to re-run the same command (`blocks register` or
+`blocks publish`).
 
 ### Manage access for private agents
 
@@ -509,7 +521,7 @@ republish. Reference checklist:
    Schema Rules](#io-schema-rules). When adding streaming, see
    [Streaming Agents](#streaming-agents).
 4. **Validate** with `cd <agent-dir> && blocks check`.
-5. **Republish** per [Publishing & Republishing](#publishing--republishing).
+5. **Re-register (or republish)** per [Registering & Publishing](#registering--publishing).
    The published metadata is what consumers see -- don't rely on
    `blocks run` alone to confirm the change is live.
 6. **Restart** the running agent so the new handler is loaded -- ask
@@ -546,7 +558,7 @@ don't assume they want to edit the handler.
    - **As-is:** Skip handler edits. Authenticate (`blocks login
      --write-env` if needed), then `blocks register` (private + free,
      the recommended first step) per
-     [Publishing & Republishing](#publishing--republishing). Use
+     [Registering & Publishing](#registering--publishing). Use
      `blocks publish` instead if the user explicitly wants public/paid.
    - **Changes first:** Edit handler / IO schema, then register (or
      publish).
@@ -895,7 +907,7 @@ is already terminal (live-only data is gone; artifacts persist).
 | `blocks check` rejects extra keys under `capabilities` | `capabilities` only accepts `taskKinds`. Streaming config goes in the top-level `streams` block. |
 | `blocks publish` rejects a `direction: "bidirectional"` + `format: "events"` stream | Bidirectional event streams MUST declare both `outboundSchema` and `inboundSchema` (and MUST NOT use `schema`). Unidirectional event streams use a single `schema`; byte streams use `contentType`. See [Streaming Agents](#streaming-agents). |
 | `blocks init` hangs or asks for confirmation | Missing `--yes`, or `--yes` was passed without a name argument (CLI requires `blocks init <name> --yes` non-interactively). Always include both. |
-| `blocks publish` hangs after the `[OK]` validation lines | Missing one of `--billing-mode`, `--listing`, or `--accept-terms` in a non-interactive shell. See [Publishing & Republishing → Non-interactive publish flags](#non-interactive-publish-flags). |
+| `blocks publish` hangs after the `[OK]` validation lines | Missing one of `--billing-mode`, `--listing`, or `--accept-terms` in a non-interactive shell. See [Registering & Publishing → Non-interactive publish flags](#non-interactive-publish-flags). |
 | `blocks invite send` returns `either --email or --org is required` (or 4xx) | The two flags are required and mutually exclusive -- pass exactly one. |
 | Bare `blocks login` finishes but `BLOCKS_API_KEY` is missing in `.env` | Non-TTY auto-detection skipped the write-env prompt. Re-run with explicit `--write-env` (and `--dir <name>` if invoking from a parent directory). |
 

--- a/skills/references/python-reference.md
+++ b/skills/references/python-reference.md
@@ -105,7 +105,7 @@ Add this to `agent-card.json` (peer of `identity`, `capabilities`, `io`):
 - For request-only agents (`taskKinds: ["request"]`), streams must contain only `_default`.
 - Both `direction` and `format` are required on each stream.
 - A stream declared with `affinity: "shared"` is a cross-task broadcast and is **pipe-only** — `create_stream()` raises on request tasks, and per-task `stream.end()` does not publish a `stream_end` marker. See `dev_docs/SDK_CONTRACT.md` §4.4.2, §8.4.1a, §8.7.3a, §8.7.4 for the lifecycle contract.
-- Re-publish (`blocks publish`) after adding `streams`.
+- Re-register or re-publish (`blocks register` / `blocks publish`) after adding `streams`. Use `blocks publish` here if the agent has already been promoted to public or paid — `blocks register` would reset the listing back to private+free.
 
 `create_stream` accepts keyword-only options: `direction` (`"outbound"`|`"inbound"`|`"bidirectional"`, default `"outbound"`), `on_activate`, `metadata`, `external` (bool), `format` (`"bytes"`|`"events"`), `bundle_size_bytes`, `max_latency_ms`, `declared_stream` (omit when the card declares a single stream -- the SDK resolves it automatically; **required** when the card declares multiple streams), `subscribe_grace_ms`. The SDK derives the channel from `declared_stream` plus the card's affinity; handler code cannot specify the channel suffix directly.
 


### PR DESCRIPTION
## Node SDK & Python SDK

### Changed
- When you start an instance for an agent that isn't in the registry, the error now points you to the recommended first step — `blocks register` (private and free) — alongside `blocks publish` for public or paid listings.
