### PR TITLE
SDK + CLI v1.0.6: Add advanced streaming example for Node and Python

### DIFF
--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -39,7 +39,7 @@ func init() {
 	initCmd.Flags().StringVarP(&initType, "type", "t", "", "Deprecated: use --mode")
 	_ = initCmd.Flags().MarkDeprecated("type", "use --mode instead")
 	initCmd.Flags().StringSliceVar(&initAgents, "agent", nil, "Bare agent name the page calls (repeatable; required with --mode webapp)")
-	initCmd.Flags().StringVar(&initBlocksBaseURL, "blocks-base-url", "", "Override the Blocks asset base URL (default: https://blocks.ai)")
+	initCmd.Flags().StringVar(&initBlocksBaseURL, "blocks-base-url", "", "Override the Blocks asset base URL (default: https://app.blocks.ai)")
 
 	rootCmd.AddCommand(initCmd)
 }

--- a/cli/internal/scaffold/embed_generator_test.go
+++ b/cli/internal/scaffold/embed_generator_test.go
@@ -52,7 +52,7 @@ func loadFixtureCard(t *testing.T, fixtureName, agentName string, status int) *c
 func defaultVars() EmbedVars {
 	return EmbedVars{
 		WidgetVersion:      "0.1.0",
-		BlocksAssetBaseUrl: "https://blocks.ai",
+		BlocksAssetBaseUrl: "https://app.blocks.ai",
 		CardSnapshotDate:   "2026-05-09",
 	}
 }

--- a/cli/internal/scaffold/scaffold.go
+++ b/cli/internal/scaffold/scaffold.go
@@ -385,7 +385,7 @@ func scaffoldWebapp(dir string, cfg wizard.Config, cards []*cardfetch.AgentCard)
 
 	baseURL := cfg.BlocksBaseURL
 	if baseURL == "" {
-		baseURL = "https://blocks.ai"
+		baseURL = "https://app.blocks.ai"
 	}
 
 	vars := EmbedVars{

--- a/cli/internal/scaffold/testdata/embed/golden/binary_input/app.js
+++ b/cli/internal/scaffold/testdata/embed/golden/binary_input/app.js
@@ -140,7 +140,7 @@
       const arr = JSON.parse(raw);
       if (!Array.isArray(arr) || arr.length === 0) return false;
       const dev = (typeof window !== 'undefined' && window.__BLOCKS_EMBED_DEV__) || null;
-      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://blocks.ai";
+      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://app.blocks.ai";
       const pageOrigin = window.location.origin;
       const agentNames = ["binary_input"];
       const expected = await BlocksAuth.computePartitionKey({ backendBaseUrl, pageOrigin, agentNames });

--- a/cli/internal/scaffold/testdata/embed/golden/binary_input/index.html
+++ b/cli/internal/scaffold/testdata/embed/golden/binary_input/index.html
@@ -13,7 +13,7 @@
   <script>
   (function () {
     var dev = typeof window !== 'undefined' ? window.__BLOCKS_EMBED_DEV__ : null;
-    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/blocks.ai';
+    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/app.blocks.ai';
     var s = document.createElement('script');
     s.src = base + '/embed/auth.0.1.0.min.js';
     s.async = false;

--- a/cli/internal/scaffold/testdata/embed/golden/complex_multi_input/app.js
+++ b/cli/internal/scaffold/testdata/embed/golden/complex_multi_input/app.js
@@ -141,7 +141,7 @@
       const arr = JSON.parse(raw);
       if (!Array.isArray(arr) || arr.length === 0) return false;
       const dev = (typeof window !== 'undefined' && window.__BLOCKS_EMBED_DEV__) || null;
-      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://blocks.ai";
+      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://app.blocks.ai";
       const pageOrigin = window.location.origin;
       const agentNames = ["complex_multi_input"];
       const expected = await BlocksAuth.computePartitionKey({ backendBaseUrl, pageOrigin, agentNames });

--- a/cli/internal/scaffold/testdata/embed/golden/complex_multi_input/index.html
+++ b/cli/internal/scaffold/testdata/embed/golden/complex_multi_input/index.html
@@ -13,7 +13,7 @@
   <script>
   (function () {
     var dev = typeof window !== 'undefined' ? window.__BLOCKS_EMBED_DEV__ : null;
-    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/blocks.ai';
+    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/app.blocks.ai';
     var s = document.createElement('script');
     s.src = base + '/embed/auth.0.1.0.min.js';
     s.async = false;

--- a/cli/internal/scaffold/testdata/embed/golden/echo2/app.js
+++ b/cli/internal/scaffold/testdata/embed/golden/echo2/app.js
@@ -140,7 +140,7 @@
       const arr = JSON.parse(raw);
       if (!Array.isArray(arr) || arr.length === 0) return false;
       const dev = (typeof window !== 'undefined' && window.__BLOCKS_EMBED_DEV__) || null;
-      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://blocks.ai";
+      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://app.blocks.ai";
       const pageOrigin = window.location.origin;
       const agentNames = ["echo2"];
       const expected = await BlocksAuth.computePartitionKey({ backendBaseUrl, pageOrigin, agentNames });

--- a/cli/internal/scaffold/testdata/embed/golden/echo2/index.html
+++ b/cli/internal/scaffold/testdata/embed/golden/echo2/index.html
@@ -13,7 +13,7 @@
   <script>
   (function () {
     var dev = typeof window !== 'undefined' ? window.__BLOCKS_EMBED_DEV__ : null;
-    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/blocks.ai';
+    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/app.blocks.ai';
     var s = document.createElement('script');
     s.src = base + '/embed/auth.0.1.0.min.js';
     s.async = false;

--- a/cli/internal/scaffold/testdata/embed/golden/inbound_stream/app.js
+++ b/cli/internal/scaffold/testdata/embed/golden/inbound_stream/app.js
@@ -141,7 +141,7 @@
       const arr = JSON.parse(raw);
       if (!Array.isArray(arr) || arr.length === 0) return false;
       const dev = (typeof window !== 'undefined' && window.__BLOCKS_EMBED_DEV__) || null;
-      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://blocks.ai";
+      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://app.blocks.ai";
       const pageOrigin = window.location.origin;
       const agentNames = ["inbound_stream"];
       const expected = await BlocksAuth.computePartitionKey({ backendBaseUrl, pageOrigin, agentNames });

--- a/cli/internal/scaffold/testdata/embed/golden/inbound_stream/index.html
+++ b/cli/internal/scaffold/testdata/embed/golden/inbound_stream/index.html
@@ -13,7 +13,7 @@
   <script>
   (function () {
     var dev = typeof window !== 'undefined' ? window.__BLOCKS_EMBED_DEV__ : null;
-    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/blocks.ai';
+    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/app.blocks.ai';
     var s = document.createElement('script');
     s.src = base + '/embed/auth.0.1.0.min.js';
     s.async = false;

--- a/cli/internal/scaffold/testdata/embed/golden/multi_echo2_stest1/app.js
+++ b/cli/internal/scaffold/testdata/embed/golden/multi_echo2_stest1/app.js
@@ -145,7 +145,7 @@
       const arr = JSON.parse(raw);
       if (!Array.isArray(arr) || arr.length === 0) return false;
       const dev = (typeof window !== 'undefined' && window.__BLOCKS_EMBED_DEV__) || null;
-      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://blocks.ai";
+      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://app.blocks.ai";
       const pageOrigin = window.location.origin;
       const agentNames = ["echo2", "stest1"];
       const expected = await BlocksAuth.computePartitionKey({ backendBaseUrl, pageOrigin, agentNames });

--- a/cli/internal/scaffold/testdata/embed/golden/multi_echo2_stest1/index.html
+++ b/cli/internal/scaffold/testdata/embed/golden/multi_echo2_stest1/index.html
@@ -13,7 +13,7 @@
   <script>
   (function () {
     var dev = typeof window !== 'undefined' ? window.__BLOCKS_EMBED_DEV__ : null;
-    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/blocks.ai';
+    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/app.blocks.ai';
     var s = document.createElement('script');
     s.src = base + '/embed/auth.0.1.0.min.js';
     s.async = false;

--- a/cli/internal/scaffold/testdata/embed/golden/pipe_only/app.js
+++ b/cli/internal/scaffold/testdata/embed/golden/pipe_only/app.js
@@ -140,7 +140,7 @@
       const arr = JSON.parse(raw);
       if (!Array.isArray(arr) || arr.length === 0) return false;
       const dev = (typeof window !== 'undefined' && window.__BLOCKS_EMBED_DEV__) || null;
-      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://blocks.ai";
+      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://app.blocks.ai";
       const pageOrigin = window.location.origin;
       const agentNames = ["pipe_only"];
       const expected = await BlocksAuth.computePartitionKey({ backendBaseUrl, pageOrigin, agentNames });

--- a/cli/internal/scaffold/testdata/embed/golden/pipe_only/index.html
+++ b/cli/internal/scaffold/testdata/embed/golden/pipe_only/index.html
@@ -13,7 +13,7 @@
   <script>
   (function () {
     var dev = typeof window !== 'undefined' ? window.__BLOCKS_EMBED_DEV__ : null;
-    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/blocks.ai';
+    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/app.blocks.ai';
     var s = document.createElement('script');
     s.src = base + '/embed/auth.0.1.0.min.js';
     s.async = false;

--- a/cli/internal/scaffold/testdata/embed/golden/private_me/app.js
+++ b/cli/internal/scaffold/testdata/embed/golden/private_me/app.js
@@ -140,7 +140,7 @@
       const arr = JSON.parse(raw);
       if (!Array.isArray(arr) || arr.length === 0) return false;
       const dev = (typeof window !== 'undefined' && window.__BLOCKS_EMBED_DEV__) || null;
-      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://blocks.ai";
+      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://app.blocks.ai";
       const pageOrigin = window.location.origin;
       const agentNames = ["private_me"];
       const expected = await BlocksAuth.computePartitionKey({ backendBaseUrl, pageOrigin, agentNames });

--- a/cli/internal/scaffold/testdata/embed/golden/private_me/index.html
+++ b/cli/internal/scaffold/testdata/embed/golden/private_me/index.html
@@ -13,7 +13,7 @@
   <script>
   (function () {
     var dev = typeof window !== 'undefined' ? window.__BLOCKS_EMBED_DEV__ : null;
-    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/blocks.ai';
+    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/app.blocks.ai';
     var s = document.createElement('script');
     s.src = base + '/embed/auth.0.1.0.min.js';
     s.async = false;

--- a/cli/internal/scaffold/testdata/embed/golden/request_pipe/app.js
+++ b/cli/internal/scaffold/testdata/embed/golden/request_pipe/app.js
@@ -140,7 +140,7 @@
       const arr = JSON.parse(raw);
       if (!Array.isArray(arr) || arr.length === 0) return false;
       const dev = (typeof window !== 'undefined' && window.__BLOCKS_EMBED_DEV__) || null;
-      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://blocks.ai";
+      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://app.blocks.ai";
       const pageOrigin = window.location.origin;
       const agentNames = ["request_pipe"];
       const expected = await BlocksAuth.computePartitionKey({ backendBaseUrl, pageOrigin, agentNames });

--- a/cli/internal/scaffold/testdata/embed/golden/request_pipe/index.html
+++ b/cli/internal/scaffold/testdata/embed/golden/request_pipe/index.html
@@ -13,7 +13,7 @@
   <script>
   (function () {
     var dev = typeof window !== 'undefined' ? window.__BLOCKS_EMBED_DEV__ : null;
-    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/blocks.ai';
+    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/app.blocks.ai';
     var s = document.createElement('script');
     s.src = base + '/embed/auth.0.1.0.min.js';
     s.async = false;

--- a/cli/internal/scaffold/testdata/embed/golden/stest1/app.js
+++ b/cli/internal/scaffold/testdata/embed/golden/stest1/app.js
@@ -141,7 +141,7 @@
       const arr = JSON.parse(raw);
       if (!Array.isArray(arr) || arr.length === 0) return false;
       const dev = (typeof window !== 'undefined' && window.__BLOCKS_EMBED_DEV__) || null;
-      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://blocks.ai";
+      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://app.blocks.ai";
       const pageOrigin = window.location.origin;
       const agentNames = ["stest1"];
       const expected = await BlocksAuth.computePartitionKey({ backendBaseUrl, pageOrigin, agentNames });

--- a/cli/internal/scaffold/testdata/embed/golden/stest1/index.html
+++ b/cli/internal/scaffold/testdata/embed/golden/stest1/index.html
@@ -13,7 +13,7 @@
   <script>
   (function () {
     var dev = typeof window !== 'undefined' ? window.__BLOCKS_EMBED_DEV__ : null;
-    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/blocks.ai';
+    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/app.blocks.ai';
     var s = document.createElement('script');
     s.src = base + '/embed/auth.0.1.0.min.js';
     s.async = false;

--- a/cli/internal/scaffold/testdata/embed/golden/text_input/app.js
+++ b/cli/internal/scaffold/testdata/embed/golden/text_input/app.js
@@ -140,7 +140,7 @@
       const arr = JSON.parse(raw);
       if (!Array.isArray(arr) || arr.length === 0) return false;
       const dev = (typeof window !== 'undefined' && window.__BLOCKS_EMBED_DEV__) || null;
-      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://blocks.ai";
+      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://app.blocks.ai";
       const pageOrigin = window.location.origin;
       const agentNames = ["text_input"];
       const expected = await BlocksAuth.computePartitionKey({ backendBaseUrl, pageOrigin, agentNames });

--- a/cli/internal/scaffold/testdata/embed/golden/text_input/index.html
+++ b/cli/internal/scaffold/testdata/embed/golden/text_input/index.html
@@ -13,7 +13,7 @@
   <script>
   (function () {
     var dev = typeof window !== 'undefined' ? window.__BLOCKS_EMBED_DEV__ : null;
-    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/blocks.ai';
+    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/app.blocks.ai';
     var s = document.createElement('script');
     s.src = base + '/embed/auth.0.1.0.min.js';
     s.async = false;

--- a/cli/internal/scaffold/testdata/embed/golden/unknown_input/app.js
+++ b/cli/internal/scaffold/testdata/embed/golden/unknown_input/app.js
@@ -140,7 +140,7 @@
       const arr = JSON.parse(raw);
       if (!Array.isArray(arr) || arr.length === 0) return false;
       const dev = (typeof window !== 'undefined' && window.__BLOCKS_EMBED_DEV__) || null;
-      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://blocks.ai";
+      const backendBaseUrl = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : "https://app.blocks.ai";
       const pageOrigin = window.location.origin;
       const agentNames = ["unknown_input"];
       const expected = await BlocksAuth.computePartitionKey({ backendBaseUrl, pageOrigin, agentNames });

--- a/cli/internal/scaffold/testdata/embed/golden/unknown_input/index.html
+++ b/cli/internal/scaffold/testdata/embed/golden/unknown_input/index.html
@@ -13,7 +13,7 @@
   <script>
   (function () {
     var dev = typeof window !== 'undefined' ? window.__BLOCKS_EMBED_DEV__ : null;
-    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/blocks.ai';
+    var base = (dev && dev.backendBaseUrl) ? dev.backendBaseUrl : 'https:\/\/app.blocks.ai';
     var s = document.createElement('script');
     s.src = base + '/embed/auth.0.1.0.min.js';
     s.async = false;

--- a/cli/internal/wizard/wizard.go
+++ b/cli/internal/wizard/wizard.go
@@ -93,7 +93,7 @@ type Config struct {
 
 	// Webapp-scaffold fields (only used when Mode == "webapp").
 	Agents        []string // one or more bare agent names (each ^[a-zA-Z0-9_]+$)
-	BlocksBaseURL string   // defaults to "https://blocks.ai" when empty
+	BlocksBaseURL string   // defaults to "https://app.blocks.ai" when empty
 }
 
 // ValidateAgentName checks that name matches /^[a-zA-Z0-9_]+$/.

--- a/docs/embed-multi-agent.md
+++ b/docs/embed-multi-agent.md
@@ -99,7 +99,7 @@ the summary — chaining three agents in sequence.
 ```html
 <!-- index.html -->
 <script src="/__blocks_embed_dev.js"></script>
-<script src="https://blocks.ai/embed/auth.0.1.0.min.js"></script>
+<script src="https://app.blocks.ai/embed/auth.0.1.0.min.js"></script>
 <script src="app.js" defer></script>
 ```
 

--- a/embed-auth/README.md
+++ b/embed-auth/README.md
@@ -28,7 +28,7 @@ the security model is in
 ### IIFE (`<script>` tag)
 
 ```html
-<script src="https://blocks.ai/embed/auth.0.1.0.min.js"></script>
+<script src="https://app.blocks.ai/embed/auth.0.1.0.min.js"></script>
 <script>
   (async () => {
     const client = await window.BlocksAuth.signInAndGetClient({

--- a/embed-auth/rollup.config.js
+++ b/embed-auth/rollup.config.js
@@ -9,7 +9,7 @@ import dts from 'rollup-plugin-dts';
 // Build-time injection of the default Blocks backend base URL.
 // Override with `BLOCKS_BACKEND_BASE_URL=...` for on-prem / staging builds.
 const BACKEND_BASE_URL_DEFAULT =
-  process.env.BLOCKS_BACKEND_BASE_URL || 'https://blocks.ai';
+  process.env.BLOCKS_BACKEND_BASE_URL || 'https://app.blocks.ai';
 
 const replacePlugin = () =>
   replace({

--- a/embed-auth/src/constants.ts
+++ b/embed-auth/src/constants.ts
@@ -54,4 +54,4 @@ declare const __BACKEND_BASE_URL_DEFAULT__: string | undefined;
 export const BACKEND_BASE_URL_DEFAULT: string =
   typeof __BACKEND_BASE_URL_DEFAULT__ !== 'undefined'
     ? __BACKEND_BASE_URL_DEFAULT__
-    : 'https://blocks.ai';
+    : 'https://app.blocks.ai';

--- a/examples/node/README.md
+++ b/examples/node/README.md
@@ -29,6 +29,7 @@ SDK concept and uses current APIs.
 | [orchestrator](./orchestrator/)             | Orchestration             | Fan out sub-tasks to other agents, collect results |
 | [stock-sim](./stock-sim/)                   | Pipe streaming (provider) | Long-running stream of events                      |
 | [stock-sim-consumer](./stock-sim-consumer/) | Pipe streaming (consumer) | Submit pipe task, consume stream in real time      |
+| [advanced-stream](./advanced-stream/)       | Advanced streams          | Multi-stream, schema-validated events, and shared-affinity broadcast on one task |
 | [chat-agent](./chat-agent/)                 | Multi-turn chat           | Conversation that remembers context across turns   |
 
 ## Advanced Examples

--- a/examples/node/advanced-stream/.env.example
+++ b/examples/node/advanced-stream/.env.example
@@ -1,0 +1,11 @@
+# API key for the consumer (bk_...). Run `blocks login --write-env` to generate.
+# BLOCKS_API_KEY=bk_...
+
+# CDM config URL (provides PubNub keys + backend URL)
+# For local development, point to your backend CDM endpoint; leave unset for default CDN
+# BLOCKS_CDM_URL=http://localhost:3001/api/v1/cdm
+
+# Backend API base URL (optional). Overrides the baseUrl resolved from CDM —
+# used by the consumer to look up the agent registry. Point at a local backend
+# for development; leave unset to use the CDM-provided URL.
+# BLOCKS_BACKEND_URL=http://localhost:3001

--- a/examples/node/advanced-stream/README.md
+++ b/examples/node/advanced-stream/README.md
@@ -1,0 +1,85 @@
+# Advanced Stream (Node)
+
+Canonical example for **advanced streaming**. A single pipe task opens
+three named streams at once, showing how multi-stream, schema-validated
+events, and shared-affinity broadcast compose:
+
+| Declared stream | direction | format   | affinity  | Demonstrates                                  |
+| --------------- | --------- | -------- | --------- | --------------------------------------------- |
+| `events`        | outbound  | `events` | dedicated | Structured JSON events validated by a schema  |
+| `raw`           | outbound  | `bytes`  | dedicated | Raw UTF-8 chunks read as `Uint8Array`         |
+| `broadcast`     | outbound  | `events` | shared    | Shared channel with no per-task `stream_end`  |
+
+**Category:** Canonical -- advanced streams (multi-stream / events-schema / shared)
+
+## Prerequisites
+
+- Node.js 22+
+- `BLOCKS_API_KEY` (run `blocks login --write-env` to generate)
+
+## Install
+
+```bash
+cd examples/node/advanced-stream
+npm install
+```
+
+## Run the agent
+
+```bash
+blocks register   # register privately (recommended first step)
+blocks run
+```
+
+## Run the consumer
+
+In a second terminal:
+
+```bash
+npx tsx advanced-stream-consumer.ts        # default 5 ticks
+npx tsx advanced-stream-consumer.ts 10     # request 10 ticks
+```
+
+You'll see events from all three streams interleaved, each tagged with
+its declared stream name.
+
+## SDK concepts demonstrated
+
+**Provider (`handler.ts`)**
+
+- Multiple named streams on one task, each selected by `declaredStream`
+- `ctx.createStream({ declaredStream, format: 'events' | 'bytes' })` —
+  affinity (`dedicated` / `shared`) is declared on the card, not passed here
+- Writing schema-conformant events, raw bytes, and shared broadcast events
+- `ctx.cancelSignal` for cooperative cancellation; `await stream.end()`
+
+**Consumer (`advanced-stream-consumer.ts`)**
+
+- Current consumer surface: `TaskClient.create()`, `sendMessage()`,
+  `session.onStream()`, `session.waitForTerminal()`
+- Branching on `descriptor.declaredStream` and `descriptor.format`
+- Reading `stream.events<T>()` and `stream.bytes()` (`Uint8Array` chunks)
+- `stream.onError()` for subscribe-level errors
+
+## Shared streams: no per-task `stream_end`
+
+Dedicated streams emit a `stream_end` marker when the agent calls
+`stream.end()`, so a `for await` over them completes naturally. A
+**shared**-affinity stream (`broadcast`) suppresses the per-task marker —
+its channel is meant to be shared across tasks — so its reader only
+unwinds when the consumer closes the session. That's why the consumer
+does **not** await the stream readers before `waitForTerminal()`; it
+tears them down via `session.asyncClose()` afterward.
+
+Because the shared channel is stable across tasks, subscribing replays
+its recent in-memory cache. So a second run may print `broadcast` events
+from a **previous** run before its own — that's expected shared-stream
+behavior, not a bug. The dedicated `events` / `raw` streams are per-task
+and always show exactly the ticks the current task produced.
+
+## What to edit
+
+- Change the event shapes in `handler.ts` (keep the `events` stream
+  conformant to the card schema).
+- Add another declared stream to `agent-card.json` and a matching branch
+  in the consumer.

--- a/examples/node/advanced-stream/advanced-stream-consumer.ts
+++ b/examples/node/advanced-stream/advanced-stream-consumer.ts
@@ -1,0 +1,120 @@
+/**
+ * advanced-stream consumer — submits a pipe task, then reads all three
+ * declared streams concurrently, branching on each stream's declared name
+ * and wire format.
+ *
+ * Usage:
+ *   npx tsx advanced-stream-consumer.ts
+ *   npx tsx advanced-stream-consumer.ts 10        # request 10 ticks
+ *
+ * Authentication:
+ *   BLOCKS_API_KEY   API key (bk_...) — from `blocks login --write-env`.
+ *   BLOCKS_CDM_URL   CDM config URL (optional — falls back to default CDN).
+ */
+
+import 'dotenv/config';
+import { TaskClient, fetchCdmConfig, getAgent, type StreamRef } from '@blocks-network/sdk';
+
+const AGENT_NAME = 'advanced_stream';
+
+const apiKey = process.env.BLOCKS_API_KEY;
+if (!apiKey) {
+  console.error('BLOCKS_API_KEY not set. Run `blocks login --write-env` first.');
+  process.exit(1);
+}
+
+async function main() {
+  const ticks = Number.parseInt(process.argv[2] ?? '', 10);
+  const requestParts = Number.isFinite(ticks)
+    ? [{ partId: 'params', text: JSON.stringify({ ticks }) }]
+    : [];
+
+  // Resolve baseUrl from BLOCKS_* env or CDM so getAgent() knows where to look.
+  const cdmUrl = process.env.BLOCKS_CDM_URL;
+  const cdm = await fetchCdmConfig(cdmUrl);
+  const baseUrl = process.env.BLOCKS_BACKEND_URL ?? cdm.api.baseUrl;
+
+  // Read the agent's registered billingMode so we pick the matching keyset.
+  // free → playground, paid → network. A mismatch puts PubNub messages on
+  // different keys and the consumer silently hangs waiting on streams.
+  // Pass apiKey so a privately-registered (not-yet-published) agent resolves —
+  // the registry returns 404 for private agents on an unauthenticated lookup.
+  const entry = await getAgent(AGENT_NAME, { baseUrl, apiKey });
+  if (!entry) {
+    console.error(`Agent "${AGENT_NAME}" not found in the registry at ${baseUrl}.`);
+    process.exit(1);
+  }
+  const billingMode = entry.billingMode ?? 'free';
+  console.log(`Registry says ${AGENT_NAME} is billingMode=${billingMode}; using ${billingMode === 'paid' ? 'network' : 'playground'} keyset.`);
+
+  const client = await TaskClient.create({ billingMode, apiKey, cdmUrl, baseUrl });
+
+  console.log(`Submitting pipe task to ${AGENT_NAME}${requestParts.length ? ` (ticks=${ticks})` : ''}...`);
+  const session = await client.sendMessage({
+    agentName: AGENT_NAME,
+    taskKind: 'pipe',
+    // Pipe tasks require a duration (max lifetime in minutes). The agent
+    // ends its streams after `ticks`, well before this cap.
+    duration: 1,
+    requestParts,
+  });
+  console.log(`Task created: ${session.taskId}`);
+  console.log('---');
+
+  // Read every declared stream concurrently. Each is handled by name and
+  // format, so adding a stream to the card only means adding a branch.
+  //
+  // Readers are fire-and-forget: a dedicated stream's `for await` ends
+  // naturally when the agent calls stream.end() (which emits a stream_end
+  // marker). A *shared*-affinity stream emits no per-task stream_end, so its
+  // reader only unwinds when we close the session below — that is expected,
+  // and is exactly why we don't `await` the readers before terminal.
+  const seen = new Set<string>();
+  session.onStream((streamRef) => {
+    const { declaredStream, format, affinity, streamId } = streamRef.descriptor;
+    const name = declaredStream ?? streamId;
+    if (seen.has(name)) return;
+    seen.add(name);
+    console.log(`Stream discovered: ${name} (format=${format}, affinity=${affinity})`);
+    void readStream(name, format, streamRef);
+  });
+
+  const terminal = await session.waitForTerminal(60_000);
+  console.log(`--- Task ${terminal.state} ---`);
+
+  // Closing the session unsubscribes and unwinds any still-open readers
+  // (notably the shared broadcast stream, which has no per-task stream_end).
+  await session.asyncClose();
+  client.destroy();
+  console.log('--- Done ---');
+}
+
+async function readStream(
+  name: string,
+  format: 'events' | 'bytes',
+  streamRef: StreamRef,
+): Promise<void> {
+  const stream = streamRef.open();
+  stream.onError((err) => console.error(`[${name}] stream error:`, err));
+
+  try {
+    if (format === 'bytes') {
+      const decoder = new TextDecoder();
+      for await (const chunk of stream.bytes()) {
+        process.stdout.write(`[${name}] ${decoder.decode(chunk)}`);
+      }
+    } else {
+      for await (const ev of stream.events<Record<string, unknown>>()) {
+        console.log(`[${name}]`, JSON.stringify(ev));
+      }
+    }
+    console.log(`[${name}] ended`);
+  } catch {
+    // Stream closed (e.g. session teardown for the shared broadcast stream).
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/node/advanced-stream/agent-card.json
+++ b/examples/node/advanced-stream/agent-card.json
@@ -1,0 +1,98 @@
+{
+  "identity": {
+    "agentName": "advanced_stream",
+    "displayName": "advanced-stream",
+    "description": "Demonstrates advanced streaming: three named streams on one task — a schema-validated event stream, a raw byte stream, and a shared-affinity broadcast stream.",
+    "version": "1.0.0",
+    "provider": {
+      "organization": "PubNub"
+    }
+  },
+  "capabilities": {
+    "taskKinds": [
+      "pipe"
+    ]
+  },
+  "io": {
+    "inputs": [
+      {
+        "id": "params",
+        "description": "How many ticks to emit on each stream before ending.",
+        "contentType": "application/json",
+        "required": false,
+        "example": {
+          "ticks": 5
+        },
+        "schema": {
+          "type": "object",
+          "properties": {
+            "ticks": {
+              "type": "integer",
+              "title": "Ticks",
+              "description": "Number of events/chunks to emit per stream.",
+              "default": 5
+            }
+          }
+        }
+      }
+    ]
+  },
+  "streams": {
+    "events": {
+      "direction": "outbound",
+      "format": "events",
+      "affinity": "dedicated",
+      "description": "Dedicated outbound event stream. Each event conforms to the declared schema.",
+      "schema": {
+        "type": "object",
+        "required": [
+          "tick",
+          "label",
+          "at"
+        ],
+        "properties": {
+          "tick": {
+            "type": "integer",
+            "description": "Monotonic tick counter."
+          },
+          "label": {
+            "type": "string",
+            "description": "Human-readable label for the event."
+          },
+          "at": {
+            "type": "string",
+            "description": "ISO-8601 timestamp when the event was produced."
+          }
+        }
+      }
+    },
+    "raw": {
+      "direction": "outbound",
+      "format": "bytes",
+      "affinity": "dedicated",
+      "description": "Dedicated outbound byte stream. Emits raw UTF-8 chunks consumed as Uint8Array.",
+      "contentType": "text/plain"
+    },
+    "broadcast": {
+      "direction": "outbound",
+      "format": "events",
+      "affinity": "shared",
+      "description": "Shared-affinity outbound event stream. No per-task stream_end marker; multiple tasks can fan in to one shared channel."
+    }
+  },
+  "tags": [
+    {
+      "id": "advanced-streams",
+      "name": "Advanced Streams",
+      "description": "Multi-stream, schema-validated events, and shared-affinity broadcast on a single task."
+    }
+  ],
+  "runtime": {
+    "handler": "./handler.ts",
+    "handlerExport": "default",
+    "concurrency": 1,
+    "expectedInstances": 1,
+    "maxPendingBacklog": 10,
+    "maxRunningTimeSec": 60
+  }
+}

--- a/examples/node/advanced-stream/handler.ts
+++ b/examples/node/advanced-stream/handler.ts
@@ -1,0 +1,136 @@
+import type { HandlerResult, StartTaskMessage, TaskContext } from '@blocks-network/sdk';
+
+/**
+ * advanced-stream handler.
+ *
+ * Demonstrates three streaming patterns on a single pipe task, each
+ * selected by its `declaredStream` name from the agent card:
+ *
+ *   - `events`    outbound, format: 'events'  — structured JSON events that
+ *                 conform to the schema declared on the card.
+ *   - `raw`       outbound, format: 'bytes'   — raw UTF-8 chunks the consumer
+ *                 reads as Uint8Array.
+ *   - `broadcast` outbound, format: 'events', affinity: 'shared' — a shared
+ *                 channel with no per-task stream_end marker.
+ *
+ * Affinity ('dedicated' vs 'shared') is declared on the card, not passed to
+ * createStream(). The handler only names the stream via `declaredStream`.
+ */
+export default async function handler(
+  task: StartTaskMessage,
+  ctx?: TaskContext,
+): Promise<HandlerResult> {
+  const log = (msg: string) => console.log(`[advanced-stream] ${msg}`);
+
+  if (!ctx) {
+    return {
+      artifacts: [{ data: JSON.stringify({ error: 'TaskContext is required for streaming' }), mimeType: 'application/json' }],
+    };
+  }
+
+  if (task.taskKind && task.taskKind !== 'pipe') {
+    throw new Error('advanced-stream only supports pipe tasks');
+  }
+
+  const ticks = parseTicks(task.requestParts);
+  log(`Task ${task.taskId}: emitting ${ticks} tick(s) on each stream`);
+
+  // Open all three streams up front. Each is selected by its card-declared
+  // name; there are no invented stream IDs and no post-create sleeps.
+  const events = await ctx.createStream({ declaredStream: 'events', format: 'events' });
+  const raw = await ctx.createStream({ declaredStream: 'raw', format: 'bytes' });
+  const broadcast = await ctx.createStream({ declaredStream: 'broadcast', format: 'events' });
+  log(`Streams open: events=${events.channel} raw=${raw.channel} broadcast=${broadcast.channel}`);
+
+  ctx.reportStatus(`Streaming ${ticks} ticks across events/raw/broadcast...`);
+
+  const encoder = new TextEncoder();
+  let emitted = 0;
+
+  try {
+    for (let tick = 1; tick <= ticks && !ctx.cancelSignal.aborted; tick += 1) {
+      // Schema-validated event: { tick, label, at } matches the card schema.
+      events.write({ tick, label: `event #${tick}`, at: new Date().toISOString() });
+
+      // Raw bytes: consumer decodes each chunk from Uint8Array.
+      raw.write(encoder.encode(`chunk ${tick}\n`));
+
+      // Shared broadcast: fans in to a channel shared across tasks.
+      broadcast.write({ tick, kind: 'broadcast' });
+
+      emitted += 1;
+      await sleepMs(500, ctx.cancelSignal);
+    }
+  } catch (err) {
+    if (!isAbortError(err)) {
+      throw err;
+    }
+  }
+
+  // end() publishes a stream_end marker on dedicated streams so consumers
+  // know they are complete. Shared streams suppress the per-task marker.
+  await Promise.all([events.end(), raw.end(), broadcast.end()]);
+  log(`Streams ended (${emitted} ticks emitted)`);
+
+  const completionReason = ctx.isCancelled ? 'canceled' : 'completed';
+  ctx.reportStatus(`Streaming ${completionReason} (${emitted} ticks)`);
+
+  return {
+    artifacts: [{
+      data: JSON.stringify({ ticksRequested: ticks, ticksEmitted: emitted, completionReason }, null, 2),
+      mimeType: 'application/json',
+    }],
+  };
+}
+
+const DEFAULT_TICKS = 5;
+const MAX_TICKS = 50;
+
+function parseTicks(parts: unknown[] | undefined): number {
+  for (const part of parts ?? []) {
+    const record = coerceRecord(part);
+    if (record && typeof record.ticks === 'number' && Number.isFinite(record.ticks)) {
+      return Math.min(MAX_TICKS, Math.max(1, Math.trunc(record.ticks)));
+    }
+  }
+  return DEFAULT_TICKS;
+}
+
+function coerceRecord(part: unknown): Record<string, unknown> | undefined {
+  if (part === null || typeof part !== 'object' || Array.isArray(part)) {
+    return undefined;
+  }
+  const record = part as Record<string, unknown>;
+  if (typeof record.text === 'string') {
+    try {
+      const parsed = JSON.parse(record.text);
+      if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // text is not JSON — fall through to the raw record
+    }
+  }
+  return record;
+}
+
+function sleepMs(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener('abort', onAbort);
+      reject(new Error('aborted'));
+    };
+
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.message === 'aborted';
+}

--- a/examples/node/advanced-stream/package.json
+++ b/examples/node/advanced-stream/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "advanced-stream",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "start": "blocks run",
+    "check": "blocks check",
+    "consumer": "npx tsx advanced-stream-consumer.ts"
+  },
+  "dependencies": {
+    "@blocks-network/sdk": "*",
+    "dotenv": "^16.4.5",
+    "pubnub": "^8.0.0"
+  },
+  "devDependencies": {
+    "tsx": "~4.21.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -29,6 +29,7 @@ SDK concept and uses current APIs.
 | [orchestrator](./orchestrator/)             | Orchestration             | Fan out sub-tasks to other agents, collect results |
 | [stock-sim](./stock-sim/)                   | Pipe streaming (provider) | Long-running stream of events                      |
 | [stock-sim-consumer](./stock-sim-consumer/) | Pipe streaming (consumer) | Submit pipe task, consume stream in real time      |
+| [advanced-stream](./advanced-stream/)       | Advanced streams          | Multi-stream, schema-validated events, and shared-affinity broadcast on one task |
 | [chat-agent](./chat-agent/)                 | Multi-turn chat           | Conversation that remembers context across turns   |
 
 ## Advanced Examples

--- a/examples/python/advanced-stream/.env.example
+++ b/examples/python/advanced-stream/.env.example
@@ -1,0 +1,11 @@
+# API key for the consumer (bk_...). Run `blocks login --write-env` to generate.
+# BLOCKS_API_KEY=bk_...
+
+# CDM config URL (provides PubNub keys + backend URL)
+# For local development, point to your backend CDM endpoint; leave unset for default CDN
+# BLOCKS_CDM_URL=http://localhost:3001/api/v1/cdm
+
+# Backend API base URL (optional). Overrides the base_url resolved from CDM —
+# used by the consumer to look up the agent registry. Point at a local backend
+# for development; leave unset to use the CDM-provided URL.
+# BLOCKS_BACKEND_URL=http://localhost:3001

--- a/examples/python/advanced-stream/README.md
+++ b/examples/python/advanced-stream/README.md
@@ -1,0 +1,86 @@
+# Advanced Stream (Python)
+
+Canonical example for **advanced streaming**. A single pipe task opens
+three named streams at once, showing how multi-stream, schema-validated
+events, and shared-affinity broadcast compose:
+
+| Declared stream | direction | format   | affinity  | Demonstrates                                  |
+| --------------- | --------- | -------- | --------- | --------------------------------------------- |
+| `events`        | outbound  | `events` | dedicated | Structured JSON events validated by a schema  |
+| `raw`           | outbound  | `bytes`  | dedicated | Raw UTF-8 chunks read as `bytes`              |
+| `broadcast`     | outbound  | `events` | shared    | Shared channel with no per-task `stream_end`  |
+
+**Category:** Canonical -- advanced streams (multi-stream / events-schema / shared)
+
+## Prerequisites
+
+- Python 3.10+
+- `BLOCKS_API_KEY` (run `blocks login --write-env` to generate)
+
+## Install
+
+```bash
+cd examples/python/advanced-stream
+pip install -e .            # agent
+pip install -e ".[consumer]"  # + python-dotenv for the consumer
+```
+
+## Run the agent
+
+```bash
+blocks register   # register privately (recommended first step)
+blocks run
+```
+
+## Run the consumer
+
+In a second terminal:
+
+```bash
+python main.py        # default 5 ticks
+python main.py 10     # request 10 ticks
+```
+
+You'll see events from all three streams interleaved, each tagged with
+its declared stream name.
+
+## SDK concepts demonstrated
+
+**Provider (`handler.py`)**
+
+- Multiple named streams on one task, each selected by `declared_stream`
+- `ctx.create_stream(declared_stream=..., format="events" | "bytes")` —
+  affinity (`dedicated` / `shared`) is declared on the card, not passed here
+- Writing schema-conformant events, raw bytes, and shared broadcast events
+- `ctx.is_cancelled` for cooperative cancellation; `stream.end()`
+
+**Consumer (`main.py`)**
+
+- Current consumer surface: `TaskClient.create()`, `send_message()`,
+  `session.on_stream()`, `session.wait_for_terminal()`
+- Branching on `descriptor.declared_stream` and `descriptor.format`
+- Reading `stream.events()` and `stream.bytes()` on daemon threads
+  (Python stream iterators are blocking)
+- `stream.on_error()` for subscribe-level errors
+
+## Shared streams: no per-task `stream_end`
+
+Dedicated streams emit a `stream_end` marker when the agent calls
+`stream.end()`, so iterating them completes naturally. A **shared**-affinity
+stream (`broadcast`) suppresses the per-task marker — its channel is meant
+to be shared across tasks — so its reader thread only unwinds when the
+consumer closes the session. That's why the consumer waits for terminal
+first, then calls `session.close()` to tear the readers down.
+
+Because the shared channel is stable across tasks, subscribing replays
+its recent in-memory cache. So a second run may print `broadcast` events
+from a **previous** run before its own — that's expected shared-stream
+behavior, not a bug. The dedicated `events` / `raw` streams are per-task
+and always show exactly the ticks the current task produced.
+
+## What to edit
+
+- Change the event shapes in `handler.py` (keep the `events` stream
+  conformant to the card schema).
+- Add another declared stream to `agent-card.json` and a matching branch
+  in the consumer.

--- a/examples/python/advanced-stream/agent-card.json
+++ b/examples/python/advanced-stream/agent-card.json
@@ -1,0 +1,98 @@
+{
+  "identity": {
+    "agentName": "advanced_stream",
+    "displayName": "advanced-stream",
+    "description": "Demonstrates advanced streaming: three named streams on one task — a schema-validated event stream, a raw byte stream, and a shared-affinity broadcast stream.",
+    "version": "1.0.0",
+    "provider": {
+      "organization": "PubNub"
+    }
+  },
+  "capabilities": {
+    "taskKinds": [
+      "pipe"
+    ]
+  },
+  "io": {
+    "inputs": [
+      {
+        "id": "params",
+        "description": "How many ticks to emit on each stream before ending.",
+        "contentType": "application/json",
+        "required": false,
+        "example": {
+          "ticks": 5
+        },
+        "schema": {
+          "type": "object",
+          "properties": {
+            "ticks": {
+              "type": "integer",
+              "title": "Ticks",
+              "description": "Number of events/chunks to emit per stream.",
+              "default": 5
+            }
+          }
+        }
+      }
+    ]
+  },
+  "streams": {
+    "events": {
+      "direction": "outbound",
+      "format": "events",
+      "affinity": "dedicated",
+      "description": "Dedicated outbound event stream. Each event conforms to the declared schema.",
+      "schema": {
+        "type": "object",
+        "required": [
+          "tick",
+          "label",
+          "at"
+        ],
+        "properties": {
+          "tick": {
+            "type": "integer",
+            "description": "Monotonic tick counter."
+          },
+          "label": {
+            "type": "string",
+            "description": "Human-readable label for the event."
+          },
+          "at": {
+            "type": "string",
+            "description": "ISO-8601 timestamp when the event was produced."
+          }
+        }
+      }
+    },
+    "raw": {
+      "direction": "outbound",
+      "format": "bytes",
+      "affinity": "dedicated",
+      "description": "Dedicated outbound byte stream. Emits raw UTF-8 chunks consumed as bytes.",
+      "contentType": "text/plain"
+    },
+    "broadcast": {
+      "direction": "outbound",
+      "format": "events",
+      "affinity": "shared",
+      "description": "Shared-affinity outbound event stream. No per-task stream_end marker; multiple tasks can fan in to one shared channel."
+    }
+  },
+  "tags": [
+    {
+      "id": "advanced-streams",
+      "name": "Advanced Streams",
+      "description": "Multi-stream, schema-validated events, and shared-affinity broadcast on a single task."
+    }
+  ],
+  "runtime": {
+    "handler": "./handler.py",
+    "handlerExport": "handler",
+    "concurrency": 1,
+    "expectedInstances": 1,
+    "maxPendingBacklog": 10,
+    "maxRunningTimeSec": 60
+  }
+}

--- a/examples/python/advanced-stream/handler.py
+++ b/examples/python/advanced-stream/handler.py
@@ -1,0 +1,136 @@
+"""advanced-stream handler.
+
+Demonstrates three streaming patterns on a single pipe task, each selected
+by its ``declared_stream`` name from the agent card:
+
+  - ``events``    outbound, format="events"  — structured JSON events that
+                  conform to the schema declared on the card.
+  - ``raw``       outbound, format="bytes"   — raw UTF-8 chunks the consumer
+                  reads as bytes.
+  - ``broadcast`` outbound, format="events", affinity="shared" — a shared
+                  channel with no per-task stream_end marker.
+
+Affinity ("dedicated" vs "shared") is declared on the card, not passed to
+create_stream(). The handler only names the stream via ``declared_stream``.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from blocks_network.types import StartTaskMessage, TaskContext
+
+DEFAULT_TICKS = 5
+MAX_TICKS = 50
+
+
+def handler(task: StartTaskMessage, ctx: Optional[TaskContext] = None) -> Dict[str, Any]:
+    log = lambda msg: print(f"[advanced-stream] {msg}")
+
+    if ctx is None:
+        return {
+            "artifacts": [{"data": json.dumps({"error": "TaskContext is required for streaming"}), "mimeType": "application/json"}],
+        }
+
+    if task.task_kind and task.task_kind != "pipe":
+        raise RuntimeError("advanced-stream only supports pipe tasks")
+
+    ticks = _parse_ticks(task.request_parts)
+    log(f"Task {task.task_id}: emitting {ticks} tick(s) on each stream")
+
+    # Open all three streams up front. Each is selected by its card-declared
+    # name; there are no invented stream IDs and no post-create sleeps.
+    events = ctx.create_stream(declared_stream="events", format="events")
+    raw = ctx.create_stream(declared_stream="raw", format="bytes")
+    broadcast = ctx.create_stream(declared_stream="broadcast", format="events")
+    log(f"Streams open: events={events.channel} raw={raw.channel} broadcast={broadcast.channel}")
+
+    ctx.report_status(f"Streaming {ticks} ticks across events/raw/broadcast...")
+
+    emitted = 0
+    try:
+        tick = 0
+        while tick < ticks and not ctx.is_cancelled:
+            tick += 1
+
+            # Schema-validated event: {tick, label, at} matches the card schema.
+            events.write({"tick": tick, "label": f"event #{tick}", "at": datetime.now(timezone.utc).isoformat()})
+
+            # Raw bytes: consumer decodes each chunk from bytes.
+            raw.write(f"chunk {tick}\n".encode("utf-8"))
+
+            # Shared broadcast: fans in to a channel shared across tasks.
+            broadcast.write({"tick": tick, "kind": "broadcast"})
+
+            emitted += 1
+            _sleep_or_cancel(0.5, ctx)
+    except (_CancelledError, RuntimeError):
+        # RuntimeError from write() on an ended stream means the SDK closed
+        # the stream (e.g. SIGINT) before the loop detected cancellation.
+        pass
+
+    # end() publishes a stream_end marker on dedicated streams so consumers
+    # know they are complete. Shared streams suppress the per-task marker.
+    for stream in (events, raw, broadcast):
+        try:
+            stream.end()
+        except RuntimeError:
+            pass  # Already ended by SDK shutdown
+    log(f"Streams ended ({emitted} ticks emitted)")
+
+    completion_reason = "canceled" if ctx.is_cancelled else "completed"
+    ctx.report_status(f"Streaming {completion_reason} ({emitted} ticks)")
+
+    return {
+        "artifacts": [{
+            "data": json.dumps(
+                {"ticksRequested": ticks, "ticksEmitted": emitted, "completionReason": completion_reason},
+                indent=2,
+            ),
+            "mimeType": "application/json",
+        }],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _CancelledError(Exception):
+    pass
+
+
+def _sleep_or_cancel(seconds: float, ctx: TaskContext) -> None:
+    """Sleep in small increments, raising _CancelledError if cancelled."""
+    end = time.monotonic() + seconds
+    while time.monotonic() < end:
+        if ctx.is_cancelled:
+            raise _CancelledError()
+        time.sleep(min(0.05, end - time.monotonic()))
+
+
+def _parse_ticks(parts: Optional[List[Any]]) -> int:
+    for part in parts or []:
+        content = _parse_part_content(part)
+        value = content.get("ticks")
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return min(MAX_TICKS, max(1, int(value)))
+    return DEFAULT_TICKS
+
+
+def _parse_part_content(part: Any) -> Dict[str, Any]:
+    text = getattr(part, "text", None) if not isinstance(part, dict) else part.get("text")
+    if isinstance(text, str):
+        try:
+            parsed = json.loads(text)
+            if isinstance(parsed, dict):
+                return parsed
+        except (json.JSONDecodeError, ValueError):
+            pass
+    if isinstance(part, dict):
+        return part
+    return {}

--- a/examples/python/advanced-stream/main.py
+++ b/examples/python/advanced-stream/main.py
@@ -1,0 +1,120 @@
+"""advanced-stream consumer.
+
+Submit a pipe task, then read all three declared streams concurrently,
+branching on each stream's declared name and format.
+
+Because Python's stream iterators are blocking, each stream is read on its own
+daemon thread. Dedicated streams end naturally when the agent calls
+stream.end(); the shared ``broadcast`` stream has no per-task stream_end, so
+its reader only unwinds when we close the session after terminal.
+
+Usage:
+    python main.py           # default 5 ticks
+    python main.py 10        # request 10 ticks
+
+Environment variables:
+    BLOCKS_API_KEY  -- Blocks API key (required)
+    BLOCKS_CDM_URL  -- CDM config URL (optional, defaults to production CDN)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from blocks_network import TaskClient, get_agent, fetch_cdm_config
+
+AGENT_NAME = "advanced_stream"
+
+api_key = os.environ.get("BLOCKS_API_KEY")
+if not api_key:
+    print("BLOCKS_API_KEY not set. Run 'blocks login --write-env' first.", file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> None:
+    ticks_arg = sys.argv[1] if len(sys.argv) > 1 else None
+    request_parts = (
+        [{"partId": "params", "text": json.dumps({"ticks": int(ticks_arg)})}]
+        if ticks_arg and ticks_arg.isdigit()
+        else []
+    )
+
+    # Resolve baseUrl + the agent's registered billing mode so we pick the
+    # matching keyset (free -> playground, paid -> network).
+    cdm_url = os.environ.get("BLOCKS_CDM_URL")
+    cdm = fetch_cdm_config(cdm_url)
+    base_url = os.environ.get("BLOCKS_BACKEND_URL") or cdm.api.base_url
+
+    # Pass api_key so a privately-registered (not-yet-published) agent
+    # resolves — the registry returns 404 for private agents unauthenticated.
+    entry = get_agent(AGENT_NAME, base_url=base_url, api_key=api_key)
+    if not entry:
+        print(f'Agent "{AGENT_NAME}" not found in the registry at {base_url}.', file=sys.stderr)
+        sys.exit(1)
+    billing_mode = entry.billing_mode or "free"
+    keyset = "network" if billing_mode == "paid" else "playground"
+    print(f"Registry says {AGENT_NAME} is billing_mode={billing_mode}; using {keyset} keyset.")
+
+    client = TaskClient.create(billing_mode=billing_mode, api_key=api_key, cdm_url=cdm_url, base_url=base_url)
+
+    print(f"Submitting pipe task to {AGENT_NAME}{f' (ticks={ticks_arg})' if request_parts else ''}...")
+    # Pipe tasks require a duration (max lifetime in minutes). The agent ends
+    # its streams after `ticks`, well before this cap.
+    session = client.send_message(agent_name=AGENT_NAME, task_kind="pipe", duration=1, request_parts=request_parts)
+    print(f"Task created: {session.task_id}")
+    print("---")
+
+    seen: set[str] = set()
+    threads: list[threading.Thread] = []
+
+    def on_stream(stream_ref) -> None:
+        desc = stream_ref.descriptor
+        name = desc.declared_stream or desc.stream_id
+        if name in seen:
+            return
+        seen.add(name)
+        print(f"Stream discovered: {name} (format={desc.format}, affinity={desc.affinity})")
+        t = threading.Thread(target=_read_stream, args=(name, desc.format, stream_ref), daemon=True)
+        t.start()
+        threads.append(t)
+
+    session.on_stream(on_stream)
+
+    terminal = session.wait_for_terminal(timeout=60.0)
+    print(f"--- Task {terminal.state} ---")
+
+    # Closing the session unsubscribes and unwinds any still-open readers
+    # (notably the shared broadcast stream, which has no per-task stream_end).
+    session.close()
+    client.destroy()
+    print("--- Done ---")
+
+
+def _read_stream(name: str, fmt: str, stream_ref) -> None:
+    stream = stream_ref.open()
+    stream.on_error(lambda err: print(f"[{name}] stream error: {err}", file=sys.stderr))
+
+    try:
+        if fmt == "bytes":
+            for chunk in stream.bytes():
+                sys.stdout.write(f"[{name}] {chunk.decode('utf-8', errors='replace')}")
+                sys.stdout.flush()
+        else:
+            for event in stream.events():
+                print(f"[{name}] {json.dumps(event)}")
+        print(f"[{name}] ended")
+    except Exception as err:
+        # Expected on session teardown: closing the session unwinds the shared
+        # broadcast reader (which has no per-task stream_end) mid-iteration.
+        print(f"[{name}] reader closed: {err}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/advanced-stream/pyproject.toml
+++ b/examples/python/advanced-stream/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "advanced-stream-agent-example"
+version = "1.0.0"
+description = "Advanced-stream agent example for Blocks Network"
+requires-python = ">=3.10"
+dependencies = [
+    "blocks-network",
+]
+
+[project.optional-dependencies]
+consumer = [
+    "python-dotenv",
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -849,6 +849,35 @@
         "typescript": "^5.4.5"
       }
     },
+    "examples/node/advanced-stream": {
+      "version": "1.0.0",
+      "dependencies": {
+        "@blocks-network/sdk": "*",
+        "dotenv": "^16.4.5",
+        "pubnub": "^8.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.4.5"
+      }
+    },
+    "examples/node/advanced-stream/node_modules/pubnub": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/pubnub/-/pubnub-8.10.0.tgz",
+      "integrity": "sha512-ij/cX1cBEw3YQX3KLw4Yk+zWxXeGyEZTK/DYNEPdBn3AIeImQZMiTjX9v5DjoRr/77Igwb2rTWNslA2XWOZmzg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "agentkeepalive": "^3.5.2",
+        "buffer": "^6.0.3",
+        "cbor-js": "^0.1.0",
+        "cbor-sync": "^1.0.4",
+        "form-data": "^4.0.0",
+        "lil-uuid": "^0.1.1",
+        "node-fetch": "^2.7.0",
+        "proxy-agent": "^6.3.0",
+        "react-native-url-polyfill": "^2.0.0",
+        "text-encoding": "^0.7.0"
+      }
+    },
     "examples/node/bidi-chat": {
       "version": "1.0.0",
       "dependencies": {
@@ -3506,6 +3535,10 @@
     },
     "node_modules/adder": {
       "resolved": "examples/node/adder",
+      "link": true
+    },
+    "node_modules/advanced-stream": {
+      "resolved": "examples/node/advanced-stream",
       "link": true
     },
     "node_modules/agent-base": {

--- a/skills/references/node-reference.md
+++ b/skills/references/node-reference.md
@@ -234,7 +234,7 @@ Three browser/runtime patterns are supported (see SDK Contract
    API key. The browser calls `tokenEndpoint` to refresh. Used by
    the in-tree dashboard and any partner with their own server.
 3. **Embedded auth** (Mode 3 / partner-hosted static page) — drop-in
-   `BlocksAuth` widget served at `blocks.ai/embed/auth.<version>.min.js`
+   `BlocksAuth` widget served at `app.blocks.ai/embed/auth.<version>.min.js`
    (or `npm i @blocks-network/embed-auth`). Call
    `BlocksAuth.signInAndGetClient({ agent })` (one agent) or
    `BlocksAuth.signInAndGetClients({ agents })` (several); the widget runs a


### PR DESCRIPTION
## CLI

### Fixed
- Embedded auth widgets on deployed partner pages (Cloudflare, Vercel, Netlify) now load correctly; scaffolded projects and the widget default to the correct host instead of the marketing site, which previously caused a "failed to load" error.

## Node SDK & Python SDK

### Added
- A new advanced streaming example is now available for both Node and Python, demonstrating multi-stream output, event schemas, and shared handler patterns.
