### PR TITLE
SDK + CLI v1.0.9: Open publish and dashboard URLs on active profile's deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,7 @@ validation.
 - `blocks init --mode webapp --backend-url <url>` to explicitly set the backend API origin the deployed page calls.
 
 #### Fixed
+- `blocks publish` and `blocks dashboard` now open the "View" link on the deployment your active profile (or `BLOCKS_BACKEND_URL`) targets, instead of always opening `https://app.blocks.ai`. Set `BLOCKS_APP_BASE_URL` / `BLOCKS_DASHBOARD_URL` when your dashboard origin differs from the backend origin.
 - `blocks publish` now applies enterprise publishing behavior when you target an enterprise instance with `--api-key` before running `blocks login` for that instance, instead of falling back to Blocks Network prompts.
 - Publishing under a non-default organization now makes that organization the active one, so later `blocks run` and `blocks whoami` use it instead of the previously selected organization.
 - Windows TLS timeouts when fetching CDM config

--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pubnub/blocks-sdk/cli/internal/cdm"
 	"github.com/spf13/cobra"
 )
 
@@ -51,12 +50,18 @@ func runDashboard(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// resolveDashboardURL picks the dashboard origin. Explicit dashboard overrides
+// (BLOCKS_APP_BASE_URL / BLOCKS_DASHBOARD_URL / active profile DashboardBaseURL)
+// win via resolveAppBaseURL; otherwise fall back to the deployment origin from
+// resolveBackendURL (BLOCKS_BACKEND_URL → active profile BaseURL → ldflag
+// default → CDM) so the dashboard opens on the active profile's deployment
+// rather than always stock https://app.blocks.ai (BLOCKS-563).
 func resolveDashboardURL() (string, error) {
 	if v := resolveAppBaseURL(); v != "" {
 		return v, nil
 	}
-	if cfg, err := cdm.Get(); err == nil && cfg.Api.BaseURL != "" {
-		return cfg.Api.BaseURL, nil
+	if v := resolveBackendURL(); v != "" {
+		return v, nil
 	}
 	return "", fmt.Errorf("could not resolve dashboard URL - set BLOCKS_APP_BASE_URL or BLOCKS_DASHBOARD_URL, or ensure CDM config is reachable")
 }

--- a/cli/cmd/dashboard_test.go
+++ b/cli/cmd/dashboard_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/pubnub/blocks-sdk/cli/internal/profiles"
+)
+
+// TestResolveDashboardURLPrefersAppBaseOverride confirms an explicit dashboard
+// override (BLOCKS_APP_BASE_URL) wins over the deployment fallback.
+func TestResolveDashboardURLPrefersAppBaseOverride(t *testing.T) {
+	restore := isolateProfiles(t)
+	defer restore()
+	t.Setenv("BLOCKS_APP_BASE_URL", "https://dashboard.acme.com")
+	t.Setenv("BLOCKS_DASHBOARD_URL", "")
+	t.Setenv("BLOCKS_BACKEND_URL", "https://api.acme.com")
+
+	got, err := resolveDashboardURL()
+	if err != nil {
+		t.Fatalf("resolveDashboardURL: %v", err)
+	}
+	if got != "https://dashboard.acme.com" {
+		t.Errorf("resolveDashboardURL = %q, want dashboard override", got)
+	}
+}
+
+// TestResolveDashboardURLFallsBackToBackendEnv covers BLOCKS-563: without a
+// dashboard override, the dashboard opens on the deployment origin
+// (BLOCKS_BACKEND_URL) rather than stock CDM / app.blocks.ai.
+func TestResolveDashboardURLFallsBackToBackendEnv(t *testing.T) {
+	restore := isolateProfiles(t)
+	defer restore()
+	t.Setenv("BLOCKS_APP_BASE_URL", "")
+	t.Setenv("BLOCKS_DASHBOARD_URL", "")
+	t.Setenv("BLOCKS_BACKEND_URL", "https://blocks.acme.com")
+
+	got, err := resolveDashboardURL()
+	if err != nil {
+		t.Fatalf("resolveDashboardURL: %v", err)
+	}
+	if got != "https://blocks.acme.com" {
+		t.Errorf("resolveDashboardURL = %q, want backend-env fallback", got)
+	}
+}
+
+// TestResolveDashboardURLFallsBackToActiveProfile covers BLOCKS-563: the active
+// profile's BaseURL drives the dashboard origin when no override and no
+// BLOCKS_BACKEND_URL are set.
+func TestResolveDashboardURLFallsBackToActiveProfile(t *testing.T) {
+	restore := isolateProfiles(t)
+	defer restore()
+	_ = profiles.Upsert(profiles.DefaultProfile, profiles.Profile{
+		BaseURL: "https://blocks.acme.com", Orgs: map[string]profiles.OrgKey{},
+	}, true)
+	t.Setenv("BLOCKS_APP_BASE_URL", "")
+	t.Setenv("BLOCKS_DASHBOARD_URL", "")
+	t.Setenv("BLOCKS_BACKEND_URL", "")
+
+	got, err := resolveDashboardURL()
+	if err != nil {
+		t.Fatalf("resolveDashboardURL: %v", err)
+	}
+	if got != "https://blocks.acme.com" {
+		t.Errorf("resolveDashboardURL = %q, want active-profile fallback", got)
+	}
+}

--- a/cli/cmd/helpers.go
+++ b/cli/cmd/helpers.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"strings"
 
@@ -181,6 +182,17 @@ func currentIntendedBackendURL() (string, error) {
 	return resolveWebappBackendURL("", "")
 }
 
+// resolveAppBaseURL resolves an explicit dashboard origin (empty if none).
+// Precedence: BLOCKS_APP_BASE_URL → BLOCKS_DASHBOARD_URL → active profile
+// DashboardBaseURL. The two env vars are the caller's direct intent and always
+// win. The profile's stored DashboardBaseURL is trusted only when it still
+// describes the deployment being targeted: if BLOCKS_BACKEND_URL is set and
+// diverges from the profile's own BaseURL, the caller is publishing to a
+// different backend than the one the profile was logged into, so the saved
+// dashboard origin is stale and is skipped — the caller then falls back to
+// resolveBackendURL(), which honors BLOCKS_BACKEND_URL. Without this guard a
+// publish to deployment B via BLOCKS_BACKEND_URL would still open deployment
+// A's dashboard (BLOCKS-563).
 func resolveAppBaseURL() string {
 	if v := strings.TrimSpace(os.Getenv(blocksAppBaseURLEnv)); v != "" {
 		return v
@@ -188,10 +200,51 @@ func resolveAppBaseURL() string {
 	if v := strings.TrimSpace(os.Getenv(blocksDashboardURLEnv)); v != "" {
 		return v
 	}
-	if _, p, err := profiles.Active(); err == nil && p.DashboardBaseURL != "" {
+	if _, p, err := profiles.Active(); err == nil && p.DashboardBaseURL != "" && !backendOverrideDivergesFromProfile(p) {
 		return p.DashboardBaseURL
 	}
 	return ""
+}
+
+// backendOverrideDivergesFromProfile reports whether BLOCKS_BACKEND_URL is set
+// to a different deployment than the profile's own BaseURL. When it does, the
+// profile's cached dashboard origin no longer describes the targeted backend.
+// An unset override, or one whose normalized base URL matches the profile's
+// BaseURL, is not a divergence. Comparison normalizes scheme/host case,
+// default ports (:443/:80), and trailing slashes, but KEEPS the path: the CLI
+// uses BaseURL as a full request prefix (`BaseURL + "/api/v1/..."`), so
+// same-host path-prefixed deployments (e.g. `https://host/tenant-a` vs
+// `/tenant-b`) are distinct. An override that fails to parse is treated as a
+// divergence (fail safe toward the backend fallback).
+func backendOverrideDivergesFromProfile(p *profiles.Profile) bool {
+	override := strings.TrimSpace(os.Getenv("BLOCKS_BACKEND_URL"))
+	if override == "" {
+		return false
+	}
+	ov := normalizedBaseURL(override)
+	return ov == "" || ov != normalizedBaseURL(p.BaseURL)
+}
+
+// normalizedBaseURL parses raw into a comparable "scheme://host[:port][/path]"
+// base URL: scheme/host lowercased, the scheme's default port (443 for https,
+// 80 for http) dropped, and any trailing slash on the path trimmed. The path is
+// retained so path-prefixed multi-tenant deployments compare as distinct.
+// Returns "" when raw has no parseable host.
+func normalizedBaseURL(raw string) string {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Hostname() == "" {
+		return ""
+	}
+	scheme := strings.ToLower(u.Scheme)
+	host := strings.ToLower(u.Hostname())
+	port := u.Port()
+	if (scheme == "https" && port == "443") || (scheme == "http" && port == "80") {
+		port = ""
+	}
+	if port != "" {
+		host += ":" + port
+	}
+	return scheme + "://" + host + strings.TrimRight(u.EscapedPath(), "/")
 }
 
 func resolveClientID() string {

--- a/cli/cmd/publish.go
+++ b/cli/cmd/publish.go
@@ -16,7 +16,6 @@ import (
 	"github.com/pubnub/blocks-sdk/cli/internal/auth"
 	"github.com/pubnub/blocks-sdk/cli/internal/blocksapi"
 	"github.com/pubnub/blocks-sdk/cli/internal/branding"
-	"github.com/pubnub/blocks-sdk/cli/internal/cdm"
 	"github.com/pubnub/blocks-sdk/cli/internal/cliconfig"
 	"github.com/pubnub/blocks-sdk/cli/internal/profiles"
 	"github.com/pubnub/blocks-sdk/cli/internal/registry"
@@ -755,20 +754,23 @@ func publishedAgentURL(respBody []byte, agentName string, allowNetworkFallback b
 }
 
 // agentAppURL builds the dashboard URL for an agent. Resolution order:
-// BLOCKS_APP_BASE_URL env var → CDM api.baseUrl (only when allowNetworkFallback
-// is true). In production CDM returns the app origin (https://app.blocks.ai);
-// in local dev where frontend and backend are split, set BLOCKS_APP_BASE_URL
-// to the frontend origin. The CDM fallback is skipped in non-interactive mode
-// to avoid a potential 21s timeout stall in CI/offline environments.
+// BLOCKS_APP_BASE_URL / BLOCKS_DASHBOARD_URL → active profile DashboardBaseURL
+// (all via resolveAppBaseURL) → the deployment origin from resolveBackendURL
+// (BLOCKS_BACKEND_URL → active profile BaseURL → ldflag default → CDM), the
+// last tier only when allowNetworkFallback is true. Routing the fallback
+// through resolveBackendURL is what keeps the "View" link on the deployment
+// the publish actually targeted instead of always stock https://app.blocks.ai
+// (BLOCKS-563). In production CDM returns the app origin; in local dev where
+// frontend and backend are split, set BLOCKS_APP_BASE_URL to the frontend
+// origin. The network-dependent fallback is skipped in non-interactive mode to
+// avoid a potential 21s timeout stall in CI/offline environments.
 func agentAppURL(agentName string, allowNetworkFallback bool) string {
 	if strings.TrimSpace(agentName) == "" {
 		return ""
 	}
 	baseURL := resolveAppBaseURL()
 	if baseURL == "" && allowNetworkFallback {
-		if cfg, err := cdm.Get(); err == nil && cfg.Api.BaseURL != "" {
-			baseURL = cfg.Api.BaseURL
-		}
+		baseURL = resolveBackendURL()
 	}
 	if baseURL == "" {
 		return ""

--- a/cli/cmd/publish_test.go
+++ b/cli/cmd/publish_test.go
@@ -111,8 +111,12 @@ func TestPublishWithListingPublic(t *testing.T) {
 	if strings.Contains(strings.ToLower(output), "playground") {
 		t.Errorf("success output must not contain playground wording:\n%s", output)
 	}
-	if strings.Contains(output, "View:") {
-		t.Errorf("success output should omit View line when backend provides no URL:\n%s", output)
+	// BLOCKS-563: when the backend response carries no agentUrl, the View link
+	// falls back to the active deployment origin (BLOCKS_BACKEND_URL here), not
+	// stock app.blocks.ai and not an omitted line.
+	wantView := "View: " + ts.URL + "/agents/test_agent"
+	if !strings.Contains(output, wantView) {
+		t.Errorf("success output should show View line at the deployment origin (%q):\n%s", wantView, output)
 	}
 }
 
@@ -638,6 +642,171 @@ func TestPublishedAgentURLOmitsWithoutResolution(t *testing.T) {
 	got := publishedAgentURL([]byte(`{"status":"ok"}`), "test_agent", false)
 	if got != "" {
 		t.Errorf("publishedAgentURL = %q, want empty string", got)
+	}
+}
+
+// TestPublishedAgentURLUsesBackendURLEnvFallback covers BLOCKS-563: with no
+// dashboard override set, the "View" link must fall back to the deployment
+// origin (BLOCKS_BACKEND_URL here) rather than stock CDM / app.blocks.ai.
+func TestPublishedAgentURLUsesBackendURLEnvFallback(t *testing.T) {
+	restore := isolateProfiles(t)
+	defer restore()
+	t.Setenv("BLOCKS_APP_BASE_URL", "")
+	t.Setenv("BLOCKS_DASHBOARD_URL", "")
+	t.Setenv("BLOCKS_BACKEND_URL", "https://blocks.acme.com")
+
+	got := publishedAgentURL([]byte(`{"status":"ok"}`), "test_agent", true)
+	want := "https://blocks.acme.com/agents/test_agent"
+	if got != want {
+		t.Errorf("publishedAgentURL = %q, want %q", got, want)
+	}
+}
+
+// TestPublishedAgentURLUsesActiveProfileFallback covers BLOCKS-563: the active
+// profile's BaseURL (an enterprise/custom deployment) must drive the "View"
+// link when no dashboard override and no BLOCKS_BACKEND_URL are set.
+func TestPublishedAgentURLUsesActiveProfileFallback(t *testing.T) {
+	restore := isolateProfiles(t)
+	defer restore()
+	_ = profiles.Upsert(profiles.DefaultProfile, profiles.Profile{
+		BaseURL: "https://blocks.acme.com", Orgs: map[string]profiles.OrgKey{},
+	}, true)
+	t.Setenv("BLOCKS_APP_BASE_URL", "")
+	t.Setenv("BLOCKS_DASHBOARD_URL", "")
+	t.Setenv("BLOCKS_BACKEND_URL", "")
+
+	got := publishedAgentURL([]byte(`{"status":"ok"}`), "test_agent", true)
+	want := "https://blocks.acme.com/agents/test_agent"
+	if got != want {
+		t.Errorf("publishedAgentURL = %q, want %q", got, want)
+	}
+}
+
+// TestPublishedAgentURLDashboardOverrideWinsOverBackend ensures an explicit
+// dashboard origin (profile DashboardBaseURL) still takes precedence over the
+// deployment BaseURL fallback — the split-dashboard deployment case.
+func TestPublishedAgentURLDashboardOverrideWinsOverBackend(t *testing.T) {
+	restore := isolateProfiles(t)
+	defer restore()
+	_ = profiles.Upsert(profiles.DefaultProfile, profiles.Profile{
+		BaseURL:          "https://api.acme.com",
+		DashboardBaseURL: "https://dashboard.acme.com",
+		Orgs:             map[string]profiles.OrgKey{},
+	}, true)
+	t.Setenv("BLOCKS_APP_BASE_URL", "")
+	t.Setenv("BLOCKS_DASHBOARD_URL", "")
+	t.Setenv("BLOCKS_BACKEND_URL", "")
+
+	got := publishedAgentURL([]byte(`{"status":"ok"}`), "test_agent", true)
+	want := "https://dashboard.acme.com/agents/test_agent"
+	if got != want {
+		t.Errorf("publishedAgentURL = %q, want %q", got, want)
+	}
+}
+
+// TestPublishedAgentURLSkipsBackendFallbackWhenNonInteractive verifies the
+// network-dependent deployment fallback stays gated behind allowNetworkFallback
+// so CI/non-interactive publishes never stall on a resolveBackendURL fetch.
+func TestPublishedAgentURLSkipsBackendFallbackWhenNonInteractive(t *testing.T) {
+	restore := isolateProfiles(t)
+	defer restore()
+	_ = profiles.Upsert(profiles.DefaultProfile, profiles.Profile{
+		BaseURL: "https://blocks.acme.com", Orgs: map[string]profiles.OrgKey{},
+	}, true)
+	t.Setenv("BLOCKS_APP_BASE_URL", "")
+	t.Setenv("BLOCKS_DASHBOARD_URL", "")
+	t.Setenv("BLOCKS_BACKEND_URL", "")
+
+	got := publishedAgentURL([]byte(`{"status":"ok"}`), "test_agent", false)
+	if got != "" {
+		t.Errorf("publishedAgentURL = %q, want empty string (fallback gated off)", got)
+	}
+}
+
+// TestPublishedAgentURLBackendOverrideBeatsStaleProfileDashboard covers the
+// BLOCKS-563 precedence hole: when BLOCKS_BACKEND_URL targets a different
+// backend than the active profile was logged into, the profile's cached
+// DashboardBaseURL is stale and must be skipped so the View link follows the
+// backend actually being published to.
+func TestPublishedAgentURLBackendOverrideBeatsStaleProfileDashboard(t *testing.T) {
+	restore := isolateProfiles(t)
+	defer restore()
+	_ = profiles.Upsert(profiles.DefaultProfile, profiles.Profile{
+		BaseURL:          "https://a.example.com",
+		DashboardBaseURL: "https://dashboard.a.example.com",
+		Orgs:             map[string]profiles.OrgKey{},
+	}, true)
+	t.Setenv("BLOCKS_APP_BASE_URL", "")
+	t.Setenv("BLOCKS_DASHBOARD_URL", "")
+	t.Setenv("BLOCKS_BACKEND_URL", "https://b.example.com")
+
+	got := publishedAgentURL([]byte(`{"status":"ok"}`), "test_agent", true)
+	want := "https://b.example.com/agents/test_agent"
+	if got != want {
+		t.Errorf("publishedAgentURL = %q, want %q (must follow BLOCKS_BACKEND_URL, not stale profile dashboard)", got, want)
+	}
+}
+
+// TestPublishedAgentURLProfileDashboardKeptWhenBackendMatches ensures the
+// split-dashboard case still works: a profile whose dashboard origin differs
+// from its backend keeps that dashboard origin when BLOCKS_BACKEND_URL is unset
+// or points at the profile's own backend (not a divergence).
+func TestPublishedAgentURLProfileDashboardKeptWhenBackendMatches(t *testing.T) {
+	restore := isolateProfiles(t)
+	defer restore()
+	_ = profiles.Upsert(profiles.DefaultProfile, profiles.Profile{
+		BaseURL:          "https://a.example.com",
+		DashboardBaseURL: "https://dashboard.a.example.com",
+		Orgs:             map[string]profiles.OrgKey{},
+	}, true)
+	t.Setenv("BLOCKS_APP_BASE_URL", "")
+	t.Setenv("BLOCKS_DASHBOARD_URL", "")
+
+	// Unset override: split-dashboard origin is honored.
+	t.Setenv("BLOCKS_BACKEND_URL", "")
+	if got, want := publishedAgentURL([]byte(`{"status":"ok"}`), "test_agent", true), "https://dashboard.a.example.com/agents/test_agent"; got != want {
+		t.Errorf("unset override: publishedAgentURL = %q, want %q", got, want)
+	}
+
+	// Override equals the profile backend (trailing slash aside): still honored.
+	t.Setenv("BLOCKS_BACKEND_URL", "https://a.example.com/")
+	if got, want := publishedAgentURL([]byte(`{"status":"ok"}`), "test_agent", true), "https://dashboard.a.example.com/agents/test_agent"; got != want {
+		t.Errorf("matching override: publishedAgentURL = %q, want %q", got, want)
+	}
+
+	// Override differs only by an explicit default port / case: origin-equivalent,
+	// so the dashboard origin is still honored (not a divergence).
+	t.Setenv("BLOCKS_BACKEND_URL", "https://A.example.com:443")
+	if got, want := publishedAgentURL([]byte(`{"status":"ok"}`), "test_agent", true), "https://dashboard.a.example.com/agents/test_agent"; got != want {
+		t.Errorf("default-port override: publishedAgentURL = %q, want %q", got, want)
+	}
+}
+
+// TestPublishedAgentURLBackendOverrideDivergesByPath covers same-host,
+// path-prefixed multi-tenant deployments: BaseURL is a full request prefix, so
+// a BLOCKS_BACKEND_URL that differs only by path is a different deployment and
+// must drop the profile's cached (tenant-a) dashboard origin.
+func TestPublishedAgentURLBackendOverrideDivergesByPath(t *testing.T) {
+	restore := isolateProfiles(t)
+	defer restore()
+	_ = profiles.Upsert(profiles.DefaultProfile, profiles.Profile{
+		BaseURL:          "https://host.example.com/tenant-a",
+		DashboardBaseURL: "https://host.example.com/tenant-a/dashboard",
+		Orgs:             map[string]profiles.OrgKey{},
+	}, true)
+	t.Setenv("BLOCKS_APP_BASE_URL", "")
+	t.Setenv("BLOCKS_DASHBOARD_URL", "")
+
+	// Different path prefix → divergence → follow BLOCKS_BACKEND_URL.
+	t.Setenv("BLOCKS_BACKEND_URL", "https://host.example.com/tenant-b")
+	if got, want := publishedAgentURL([]byte(`{"status":"ok"}`), "test_agent", true), "https://host.example.com/tenant-b/agents/test_agent"; got != want {
+		t.Errorf("path divergence: publishedAgentURL = %q, want %q (must not open tenant-a dashboard)", got, want)
+	}
+
+	// Same path prefix (trailing slash aside) → not a divergence → keep dashboard.
+	t.Setenv("BLOCKS_BACKEND_URL", "https://host.example.com/tenant-a/")
+	if got, want := publishedAgentURL([]byte(`{"status":"ok"}`), "test_agent", true), "https://host.example.com/tenant-a/dashboard/agents/test_agent"; got != want {
+		t.Errorf("same path: publishedAgentURL = %q, want %q", got, want)
 	}
 }
 

--- a/skills/GETSTARTED.md
+++ b/skills/GETSTARTED.md
@@ -309,10 +309,15 @@ Consumer Projects & Trigger / Client Code.
 cd <your-agent-name> && blocks dashboard
 ```
 
-`blocks dashboard` reads the dashboard URL from the CDM config (or from
-`BLOCKS_APP_BASE_URL` / `BLOCKS_DASHBOARD_URL` if either is set), then
-opens the agent's page. To target a non-prod environment, export the
-env var before invoking:
+`blocks dashboard` reads the dashboard URL from `BLOCKS_APP_BASE_URL` /
+`BLOCKS_DASHBOARD_URL` (or the active profile's dashboard origin) if
+set, otherwise from the active deployment — `BLOCKS_BACKEND_URL`, the
+active profile's backend, or the CDM config — then opens the agent's
+page on the deployment you're targeting. When `BLOCKS_BACKEND_URL`
+points at a different backend than the active profile was logged into,
+the profile's cached dashboard origin is skipped so the link follows
+`BLOCKS_BACKEND_URL`. To target a non-prod environment, export the env
+var before invoking:
 
 ```bash
 BLOCKS_APP_BASE_URL=https://staging.blocks.ai blocks dashboard

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -162,10 +162,15 @@ cd ..
 cd <your-agent-name> && blocks dashboard
 ```
 
-Reads the dashboard URL from the CDM config (or from
-`BLOCKS_APP_BASE_URL` / `BLOCKS_DASHBOARD_URL` if either is set), then
-opens the agent's page. Override for staging / a worktree / a
-self-hosted deploy:
+Reads the dashboard URL from `BLOCKS_APP_BASE_URL` /
+`BLOCKS_DASHBOARD_URL` (or the active profile's dashboard origin) if
+set, otherwise from the active deployment — `BLOCKS_BACKEND_URL`, the
+active profile's backend, or the CDM config — so it opens the agent's
+page on the deployment you're targeting rather than always stock Blocks
+Network. When `BLOCKS_BACKEND_URL` points at a different backend than
+the active profile was logged into, the profile's cached dashboard
+origin is skipped so the link follows `BLOCKS_BACKEND_URL`. Override for
+staging / a worktree / a self-hosted deploy:
 
 ```bash
 BLOCKS_APP_BASE_URL=https://staging.blocks.ai blocks dashboard
@@ -601,11 +606,16 @@ or porting the same pattern into a separate codebase.
 cd <your-agent-name> && blocks dashboard
 ```
 
-`blocks dashboard` reads the dashboard URL from the CDM config (or
-from `BLOCKS_APP_BASE_URL` / `BLOCKS_DASHBOARD_URL` if either is
-set), then opens the agent's page. To target a non-prod environment
-(staging, a worktree, or a self-hosted deployment), export the env
-var before invoking the command, for example:
+`blocks dashboard` reads the dashboard URL from `BLOCKS_APP_BASE_URL` /
+`BLOCKS_DASHBOARD_URL` (or the active profile's dashboard origin) if
+set, otherwise from the active deployment — `BLOCKS_BACKEND_URL`, the
+active profile's backend, or the CDM config — then opens the agent's
+page on the deployment you're targeting. When `BLOCKS_BACKEND_URL`
+points at a different backend than the active profile was logged into,
+the profile's cached dashboard origin is skipped so the link follows
+`BLOCKS_BACKEND_URL`. To target a non-prod environment (staging, a
+worktree, or a self-hosted deployment), export the env var before
+invoking the command, for example:
 
 ```bash
 BLOCKS_APP_BASE_URL=https://staging.blocks.ai blocks dashboard

--- a/skills/references/node-reference.md
+++ b/skills/references/node-reference.md
@@ -667,11 +667,16 @@ blocks dashboard                    # Open the agent's dashboard page in a brows
 blocks dashboard <agent-name>       # Override the agent name (default: read from ./agent-card.json)
 ```
 
-`blocks dashboard` resolves the dashboard URL from the CDM config or
-from `BLOCKS_APP_BASE_URL` / `BLOCKS_DASHBOARD_URL` if either is set.
-Export the env var to target staging / a worktree / a self-hosted
-deployment. `blocks check` validates JSON schema **and** the file
-referenced by `runtime.handler`.
+`blocks dashboard` resolves the dashboard URL from `BLOCKS_APP_BASE_URL`
+/ `BLOCKS_DASHBOARD_URL` (or the active profile's dashboard origin) if
+set, otherwise from the active deployment — `BLOCKS_BACKEND_URL`, the
+active profile's backend, or the CDM config — so it targets the
+deployment you're on rather than always stock Blocks Network. When
+`BLOCKS_BACKEND_URL` targets a different backend than the active profile
+was logged into, the profile's cached dashboard origin is skipped so the
+link follows `BLOCKS_BACKEND_URL`. Export the env var to target
+staging / a worktree / a self-hosted deployment. `blocks check`
+validates JSON schema **and** the file referenced by `runtime.handler`.
 
 ### Manage private-agent grants (`blocks invite`)
 

--- a/skills/references/python-reference.md
+++ b/skills/references/python-reference.md
@@ -607,7 +607,13 @@ blocks dashboard <agent-name>                 # Override the agent name (default
 `blocks check` validates the JSON schema **and** the file referenced
 by `runtime.handler` -- a missing handler produces `[FAIL]` even when
 the JSON is valid. `blocks dashboard` resolves the dashboard URL from
-the CDM config or from `BLOCKS_APP_BASE_URL` / `BLOCKS_DASHBOARD_URL`.
+`BLOCKS_APP_BASE_URL` / `BLOCKS_DASHBOARD_URL` (or the active profile's
+dashboard origin) if set, otherwise from the active deployment
+(`BLOCKS_BACKEND_URL`, the active profile's backend, or the CDM config),
+so it targets the deployment you're on rather than always stock Blocks
+Network. When `BLOCKS_BACKEND_URL` targets a different backend than the
+active profile was logged into, the profile's cached dashboard origin is
+skipped so the link follows `BLOCKS_BACKEND_URL`.
 
 ### Manage private-agent grants (`blocks invite`)
 


### PR DESCRIPTION
## CLI

### Fixed
- The publish and dashboard commands now open URLs on the active profile's deployment.
