### PR TITLE
SDK + CLI v1.0.10: Publishing now prints the agent's View link even in non-interactive or offline runs when a backend URL is configured, instead of suppressing it.

### DIFF
--- a/cli/cmd/helpers.go
+++ b/cli/cmd/helpers.go
@@ -24,14 +24,8 @@ const (
 )
 
 func resolveBackendURL() string {
-	if v := os.Getenv("BLOCKS_BACKEND_URL"); v != "" {
+	if v := resolveBackendURLOffline(); v != "" {
 		return v
-	}
-	if _, p, err := profiles.Active(); err == nil && p.BaseURL != "" {
-		return p.BaseURL
-	}
-	if defaultBackendURL != "" {
-		return defaultBackendURL
 	}
 	cfg, err := cdm.Get()
 	if err != nil {
@@ -40,6 +34,24 @@ func resolveBackendURL() string {
 	}
 	if cfg.Api.BaseURL != "" {
 		return cfg.Api.BaseURL
+	}
+	return ""
+}
+
+// resolveBackendURLOffline resolves the backend origin from the tiers that need
+// no network round-trip: BLOCKS_BACKEND_URL → active profile BaseURL → ldflag
+// default. Returns "" when none is set, leaving the (network-dependent) CDM
+// fetch to resolveBackendURL. Split out so callers that must not stall on a CDM
+// fetch (e.g. non-interactive publish) can still use the offline tiers.
+func resolveBackendURLOffline() string {
+	if v := os.Getenv("BLOCKS_BACKEND_URL"); v != "" {
+		return v
+	}
+	if _, p, err := profiles.Active(); err == nil && p.BaseURL != "" {
+		return p.BaseURL
+	}
+	if defaultBackendURL != "" {
+		return defaultBackendURL
 	}
 	return ""
 }

--- a/cli/cmd/publish.go
+++ b/cli/cmd/publish.go
@@ -755,20 +755,24 @@ func publishedAgentURL(respBody []byte, agentName string, allowNetworkFallback b
 
 // agentAppURL builds the dashboard URL for an agent. Resolution order:
 // BLOCKS_APP_BASE_URL / BLOCKS_DASHBOARD_URL → active profile DashboardBaseURL
-// (all via resolveAppBaseURL) → the deployment origin from resolveBackendURL
-// (BLOCKS_BACKEND_URL → active profile BaseURL → ldflag default → CDM), the
-// last tier only when allowNetworkFallback is true. Routing the fallback
-// through resolveBackendURL is what keeps the "View" link on the deployment
-// the publish actually targeted instead of always stock https://app.blocks.ai
-// (BLOCKS-563). In production CDM returns the app origin; in local dev where
-// frontend and backend are split, set BLOCKS_APP_BASE_URL to the frontend
-// origin. The network-dependent fallback is skipped in non-interactive mode to
-// avoid a potential 21s timeout stall in CI/offline environments.
+// (all via resolveAppBaseURL) → the deployment origin's offline tiers
+// (BLOCKS_BACKEND_URL → active profile BaseURL → ldflag default) → CDM. Routing
+// the fallback through the deployment origin is what keeps the "View" link on
+// the deployment the publish actually targeted instead of always stock
+// https://app.blocks.ai (BLOCKS-563). Only the CDM tier depends on the network,
+// so only it is gated behind allowNetworkFallback — a non-interactive publish
+// with BLOCKS_BACKEND_URL (or a profile / ldflag default) set still gets a View
+// link, while CI/offline environments avoid a potential 21s CDM timeout stall.
+// In production CDM returns the app origin; in local dev where frontend and
+// backend are split, set BLOCKS_APP_BASE_URL to the frontend origin.
 func agentAppURL(agentName string, allowNetworkFallback bool) string {
 	if strings.TrimSpace(agentName) == "" {
 		return ""
 	}
 	baseURL := resolveAppBaseURL()
+	if baseURL == "" {
+		baseURL = resolveBackendURLOffline()
+	}
 	if baseURL == "" && allowNetworkFallback {
 		baseURL = resolveBackendURL()
 	}

--- a/cli/cmd/publish_test.go
+++ b/cli/cmd/publish_test.go
@@ -704,10 +704,11 @@ func TestPublishedAgentURLDashboardOverrideWinsOverBackend(t *testing.T) {
 	}
 }
 
-// TestPublishedAgentURLSkipsBackendFallbackWhenNonInteractive verifies the
-// network-dependent deployment fallback stays gated behind allowNetworkFallback
-// so CI/non-interactive publishes never stall on a resolveBackendURL fetch.
-func TestPublishedAgentURLSkipsBackendFallbackWhenNonInteractive(t *testing.T) {
+// TestPublishedAgentURLOfflineTierResolvesWhenNonInteractive verifies the
+// offline deployment tiers (here the active profile BaseURL) still resolve a
+// View link in non-interactive mode — computing it needs no network, so gating
+// them off would needlessly drop the link in CI.
+func TestPublishedAgentURLOfflineTierResolvesWhenNonInteractive(t *testing.T) {
 	restore := isolateProfiles(t)
 	defer restore()
 	_ = profiles.Upsert(profiles.DefaultProfile, profiles.Profile{
@@ -718,8 +719,28 @@ func TestPublishedAgentURLSkipsBackendFallbackWhenNonInteractive(t *testing.T) {
 	t.Setenv("BLOCKS_BACKEND_URL", "")
 
 	got := publishedAgentURL([]byte(`{"status":"ok"}`), "test_agent", false)
+	want := "https://blocks.acme.com/agents/test_agent"
+	if got != want {
+		t.Errorf("publishedAgentURL = %q, want %q (offline tier must resolve non-interactively)", got, want)
+	}
+}
+
+// TestPublishedAgentURLSkipsCDMFetchWhenNonInteractive verifies only the
+// network-dependent CDM tier is gated behind allowNetworkFallback: with no
+// offline tier set (no env, no profile BaseURL, no ldflag), a non-interactive
+// call must NOT fall through to a CDM fetch (which could stall in CI/offline).
+func TestPublishedAgentURLSkipsCDMFetchWhenNonInteractive(t *testing.T) {
+	restore := isolateProfiles(t)
+	defer restore()
+	t.Setenv("BLOCKS_APP_BASE_URL", "")
+	t.Setenv("BLOCKS_DASHBOARD_URL", "")
+	t.Setenv("BLOCKS_BACKEND_URL", "")
+	t.Setenv("BLOCKS_CDM_URL", "http://127.0.0.1:1/nonexistent")
+	cdm.Reset()
+
+	got := publishedAgentURL([]byte(`{"status":"ok"}`), "test_agent", false)
 	if got != "" {
-		t.Errorf("publishedAgentURL = %q, want empty string (fallback gated off)", got)
+		t.Errorf("publishedAgentURL = %q, want empty string (CDM fetch must stay gated off)", got)
 	}
 }
 


### PR DESCRIPTION
## CLI

### Fixed
- Publishing now prints the agent's View link even in non-interactive or offline runs when a backend URL is configured, instead of suppressing it.