### PR TITLE
SDK + CLI v1.0.11: Add custom RPC headers option to TaskClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Each component (Node SDK, Python SDK, CLI) is versioned independently.
 ### [Unreleased]
 
 #### Added
+
+- `TaskClient.create({ rpcHeaders })` — attach extra request headers to RPC calls (e.g. active-organization context). SDK-managed headers stay authoritative and cannot be overridden.
 - `sendMessage({ stream })` — opt in or out of live streaming per request task. Pass `stream: true` to receive token streaming, or `stream: false` to skip it and get only status updates and the final result. Streaming still requires the agent to support it. Pipe tasks are unaffected. Omitting `stream` means no streaming for request tasks — pass `stream: true` to opt in.
 - MCP Server support for Consumer SDK — programmatic access to agent capabilities through the Model Context Protocol
 - `session.listEvents()` for seeding full task timelines from history
@@ -88,6 +90,8 @@ consumer-side task submission, real-time event subscriptions, streaming
 ### [Unreleased]
 
 #### Added
+
+- `TaskClient.create(rpc_headers=...)` — attach extra request headers to RPC calls (e.g. active-organization context). SDK-managed headers stay authoritative and cannot be overridden.
 - `send_message(stream=...)` — opt in or out of live streaming per request task. Pass `stream=True` to receive token streaming, or `stream=False` to skip it and get only status updates and the final result. Streaming still requires the agent to support it. Pipe tasks are unaffected. Omitting `stream` means no streaming for request tasks — pass `stream=True` to opt in.
 - `session.list_events()` for seeding full task timelines from history
 - Agent-side stream APIs now match consumer-side interface

--- a/sdks/node/src/runtime/rpc-client.ts
+++ b/sdks/node/src/runtime/rpc-client.ts
@@ -23,6 +23,26 @@ export interface RpcClientConfig {
   authProvider?: AuthProvider;
   baseUrl?: string;
   agentAuth?: AgentAuth;
+  /**
+   * Optional caller-supplied request headers merged onto every RPC call.
+   * Request metadata only — NOT an authorization mechanism. Merged UNDER
+   * SDK-owned headers: a caller cannot override `Authorization`,
+   * `Content-Type`, `Blocks-Protocol-Version`, or `X-Write-Affinity`.
+   */
+  rpcHeaders?: Record<string, string>;
+}
+
+export const PROTECTED_RPC_HEADERS = new Set<string>([
+  'authorization',
+  'content-type',
+  PROTOCOL_VERSION_HEADER.toLowerCase(),
+  'x-write-affinity', // SDK-managed routing state; §14b no-fabrication
+]);
+
+export function stripProtectedHeaders(h: Record<string, string>): void {
+  for (const k of Object.keys(h)) {
+    if (PROTECTED_RPC_HEADERS.has(k.toLowerCase())) delete h[k];
+  }
 }
 
 // ============================================================================
@@ -237,10 +257,10 @@ export async function callRpc<T>(
   // agentAuth injects/captures affinity inside authenticatedFetch; we only
   // handle it directly on the non-agentAuth path below.
   const buildHeaders = (includeAffinity: boolean): Record<string, string> => {
-    const h: Record<string, string> = {
-      'Content-Type': 'application/json',
-      [PROTOCOL_VERSION_HEADER]: CURRENT_PROTOCOL_VERSION,
-    };
+    const h: Record<string, string> = { ...(config.rpcHeaders ?? {}) };
+    stripProtectedHeaders(h);
+    h['Content-Type'] = 'application/json';
+    h[PROTOCOL_VERSION_HEADER] = CURRENT_PROTOCOL_VERSION;
     const authHeader = config.authProvider?.getAuthHeader();
     if (authHeader) {
       h['Authorization'] = authHeader;

--- a/sdks/node/src/runtime/task-client.ts
+++ b/sdks/node/src/runtime/task-client.ts
@@ -92,6 +92,14 @@ export interface TaskClientOptions {
    * viewer flow; non-browser SDK callers should not use this.
    */
   anonFingerprint?: string;
+
+  /**
+   * Optional caller-supplied RPC request headers. Forwarded to callRpc and
+   * merged under SDK-owned headers (cannot override Authorization,
+   * Content-Type, Blocks-Protocol-Version, or X-Write-Affinity). Request
+   * metadata only.
+   */
+  rpcHeaders?: Record<string, string>;
 }
 
 /**
@@ -465,6 +473,7 @@ export class TaskClient {
       authProvider: options.authProvider,
       baseUrl: options.baseUrl,
       agentAuth: options.agentAuth,
+      rpcHeaders: options.rpcHeaders,
     };
     this._pubnub = options.pubnub;
     this._createPubNub = options.createPubNub;
@@ -516,6 +525,7 @@ export class TaskClient {
      * not use this.
      */
     anonFingerprint?: string;
+    rpcHeaders?: Record<string, string>;
   }): Promise<TaskClient> {
     const opts = options ?? {};
     const billingMode = opts.billingMode;
@@ -607,6 +617,7 @@ export class TaskClient {
         baseUrl,
         createSessionPubNub: sessionPubNubFactory,
         defaultOwnerId: consumerAuth.getUserId() ?? undefined,
+        rpcHeaders: opts.rpcHeaders,
       });
       client.config.authProvider = consumerAuth;
       client._consumerAuth = consumerAuth;
@@ -620,6 +631,7 @@ export class TaskClient {
       baseUrl,
       createSessionPubNub: sessionPubNubFactory,
       anonFingerprint: opts.anonFingerprint,
+      rpcHeaders: opts.rpcHeaders,
     });
   }
 

--- a/sdks/node/tests/rpcClient.test.ts
+++ b/sdks/node/tests/rpcClient.test.ts
@@ -8,6 +8,7 @@ import {
   type RpcClientConfig,
 } from '../src/runtime/rpc-client.js';
 import { StaticAuthProvider } from '../src/runtime/auth-provider.js';
+import { captureAffinity, resetAffinity } from '../src/runtime/write-affinity.js';
 
 describe('rpc-client', () => {
   // ==========================================================================
@@ -122,10 +123,12 @@ describe('rpc-client', () => {
     beforeEach(() => {
       fetchSpy = vi.fn();
       globalThis.fetch = fetchSpy;
+      resetAffinity();
     });
 
     afterEach(() => {
       globalThis.fetch = originalFetch;
+      resetAffinity();
     });
 
     it('falls back to PubNub Functions gateway when baseUrl is missing from config', async () => {
@@ -437,6 +440,117 @@ describe('rpc-client', () => {
         expect(e).toBeInstanceOf(RpcError);
         expect(e).not.toBeInstanceOf(BillingModeMismatchError);
       }
+    });
+
+    it('merges rpcHeaders onto the RPC request', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ jsonrpc: '2.0', id: 'x', result: {} }),
+      });
+      const cfg: RpcClientConfig = {
+        subscribeKey: 'sub-c-test-key',
+        baseUrl: 'http://localhost:3001',
+        rpcHeaders: { 'X-Active-Org': 'org-B' },
+      };
+      await callRpc(cfg, 'Method', {});
+      const [, init] = fetchSpy.mock.calls[0];
+      expect(init.headers['X-Active-Org']).toBe('org-B');
+      // SDK-owned headers still present and authoritative.
+      expect(init.headers['Content-Type']).toBe('application/json');
+    });
+
+    it('does not let rpcHeaders override protected headers (case-insensitive)', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ jsonrpc: '2.0', id: 'x', result: {} }),
+      });
+      const cfg: RpcClientConfig = {
+        subscribeKey: 'sub-c-test-key',
+        baseUrl: 'http://localhost:3001',
+        authProvider: new StaticAuthProvider('real-jwt'),
+        rpcHeaders: {
+          authorization: 'Bearer FORGED',
+          'Content-Type': 'text/evil',
+          'blocks-protocol-version': '0.0.0-forged',
+        },
+      };
+      await callRpc(cfg, 'Method', {});
+      const [, init] = fetchSpy.mock.calls[0];
+      expect(init.headers['Authorization']).toBe('Bearer real-jwt');
+      expect(init.headers['Content-Type']).toBe('application/json');
+      // The forged lowercase keys must not survive.
+      expect(init.headers['authorization']).toBeUndefined();
+      expect(init.headers['blocks-protocol-version']).toBeUndefined();
+    });
+
+    it('strips a caller-supplied X-Write-Affinity (fetch branch, case-insensitive)', async () => {
+      // §14b: X-Write-Affinity is SDK-managed routing state. A caller MUST NOT
+      // be able to smuggle it via rpcHeaders and force primary-DB routing.
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers(),
+        json: async () => ({ jsonrpc: '2.0', id: 'x', result: {} }),
+      });
+      const cfg: RpcClientConfig = {
+        subscribeKey: 'sub-c-test-key',
+        baseUrl: 'http://localhost:3001',
+        // Capitalized key proves the strip is case-insensitive.
+        rpcHeaders: { 'X-Write-Affinity': '9999999999' },
+      };
+      await callRpc(cfg, 'Method', {});
+      const [, init] = fetchSpy.mock.calls[0];
+      // No stored affinity exists, so no affinity header at all should go out.
+      expect(init.headers['X-Write-Affinity']).toBeUndefined();
+      expect(init.headers['x-write-affinity']).toBeUndefined();
+    });
+
+    it('strips a caller-supplied X-Write-Affinity (agentAuth branch, case-insensitive)', async () => {
+      const authenticatedFetch = vi.fn(async () => ({
+        ok: true,
+        headers: new Headers(),
+        json: async () => ({ jsonrpc: '2.0', id: 'x', result: {} }),
+      }));
+      const cfg: RpcClientConfig = {
+        subscribeKey: 'sub-c-test-key',
+        baseUrl: 'http://localhost:3001',
+        // agentAuth handles affinity inside authenticatedFetch, so the SDK's own
+        // injectAffinity does NOT run here — the strip must still remove it.
+        agentAuth: { authenticatedFetch } as unknown as RpcClientConfig['agentAuth'],
+        rpcHeaders: { 'x-write-affinity': '9999999999', 'X-Write-Affinity': '9999999999' },
+      };
+      await callRpc(cfg, 'Method', {});
+      expect(authenticatedFetch).toHaveBeenCalledTimes(1);
+      const [, init] = authenticatedFetch.mock.calls[0] as unknown as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers['X-Write-Affinity']).toBeUndefined();
+      expect(headers['x-write-affinity']).toBeUndefined();
+      // fetch must not have been used on the agentAuth branch.
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('still injects a legit SDK-captured affinity when the caller supplies none (fetch branch)', async () => {
+      const future = String(Math.floor(Date.now() / 1000) + 60);
+      captureAffinity(new Headers({ 'x-write-affinity': future }));
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers(),
+        json: async () => ({ jsonrpc: '2.0', id: 'x', result: {} }),
+      });
+      await callRpc(config, 'Method', {});
+      const [, init] = fetchSpy.mock.calls[0];
+      expect(init.headers['x-write-affinity']).toBe(future);
+    });
+
+    it('sends byte-identical headers when rpcHeaders is omitted (no regression)', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ jsonrpc: '2.0', id: 'x', result: {} }),
+      });
+      await callRpc(config, 'Method', {});
+      const [, init] = fetchSpy.mock.calls[0];
+      expect(Object.keys(init.headers).sort()).toEqual(
+        ['Content-Type', 'Blocks-Protocol-Version'].sort(),
+      );
     });
   });
 

--- a/sdks/node/tests/task-client-create.test.ts
+++ b/sdks/node/tests/task-client-create.test.ts
@@ -144,4 +144,30 @@ describe('TaskClient.create — billingMode parity', () => {
       }),
     ).toThrow("TaskClient requires a billingMode option ('free' or 'paid')");
   });
+
+  it('propagates rpcHeaders to config for a provider-mode client', async () => {
+    const client = await TaskClient.create({
+      billingMode: 'free',
+      subscribeKey: 'sub-c-test',
+      publishKey: 'pub-c-test',
+      baseUrl: 'http://localhost:3001',
+      tokenProvider: async () => ({ token: 'jwt-x', expiresIn: 60 }),
+      rpcHeaders: { 'X-Active-Org': 'org-B' },
+    });
+    // config is private; cast to read it in-test (matches existing test style).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((client as any).config.rpcHeaders).toEqual({ 'X-Active-Org': 'org-B' });
+    client.destroy();
+  });
+
+  it('propagates rpcHeaders to config for an anon-mode client', async () => {
+    const client = await TaskClient.create({
+      anonFingerprint: 'fp-owner',
+      billingMode: 'free',
+      rpcHeaders: { 'X-Active-Org': 'org-C' },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((client as any).config.rpcHeaders).toEqual({ 'X-Active-Org': 'org-C' });
+    client.destroy();
+  });
 });

--- a/sdks/python/blocks_network/rpc_client.py
+++ b/sdks/python/blocks_network/rpc_client.py
@@ -28,6 +28,31 @@ from .write_affinity import capture_affinity, inject_affinity
 T = TypeVar("T")
 
 # ============================================================================
+# RPC header merge
+# ============================================================================
+
+# SDK-owned headers that caller-supplied ``rpc_headers`` may never override.
+# Compared case-insensitively (via ``.lower()``) so no casing of a caller key
+# can slip a forged Authorization / Content-Type / protocol-version header
+# past the SDK-owned base. Parity with Node ``rpc-client``.
+_PROTECTED_RPC_HEADERS = {
+    "authorization",
+    "content-type",
+    PROTOCOL_VERSION_HEADER.lower(),
+    "x-write-affinity",  # SDK-managed routing state; §14b no-fabrication
+}
+
+
+def _merge_rpc_headers(base: Dict[str, str], extra: Optional[Dict[str, str]]) -> Dict[str, str]:
+    merged = {
+        k: v for k, v in (extra or {}).items()
+        if k.lower() not in _PROTECTED_RPC_HEADERS
+    }
+    merged.update(base)  # SDK-owned base wins
+    return merged
+
+
+# ============================================================================
 # RPC Error
 # ============================================================================
 
@@ -213,6 +238,7 @@ def call_rpc(
     base_url: Optional[str] = None,
     agent_auth: Any = None,
     auth_provider: Any = None,
+    rpc_headers: Optional[Dict[str, str]] = None,
 ) -> Any:
     """Send a JSON-RPC 2.0 request to the PubNub Functions RPC gateway.
 
@@ -260,24 +286,28 @@ def call_rpc(
                 url,
                 method="POST",
                 body=rpc_payload,
-                headers={
-                    "Content-Type": "application/json",
-                    PROTOCOL_VERSION_HEADER: CURRENT_PROTOCOL_VERSION,
-                },
+                headers=_merge_rpc_headers(
+                    {
+                        "Content-Type": "application/json",
+                        PROTOCOL_VERSION_HEADER: CURRENT_PROTOCOL_VERSION,
+                    },
+                    rpc_headers,
+                ),
             )
             return _parse_rpc_response(resp_data)
 
         return with_retry(_do_auth_request)
 
     def _build_headers() -> Dict[str, str]:
-        hdrs: Dict[str, str] = {
+        base: Dict[str, str] = {
             "Content-Type": "application/json",
             PROTOCOL_VERSION_HEADER: CURRENT_PROTOCOL_VERSION,
         }
         if auth_provider is not None:
             auth_header = auth_provider.get_auth_header()
             if auth_header:
-                hdrs["Authorization"] = auth_header
+                base["Authorization"] = auth_header
+        hdrs = _merge_rpc_headers(base, rpc_headers)
         inject_affinity(hdrs)
         return hdrs
 

--- a/sdks/python/blocks_network/task_client.py
+++ b/sdks/python/blocks_network/task_client.py
@@ -447,6 +447,7 @@ class TaskClient:
         agent_auth: Any = None,
         auth_provider: Optional[AuthProvider] = None,
         anon_fingerprint: Optional[str] = None,
+        rpc_headers: Optional[Dict[str, str]] = None,
     ) -> None:
         if billing_mode not in ("free", "paid"):
             raise ValueError(
@@ -473,6 +474,12 @@ class TaskClient:
         # gate and mints read tokens via the fingerprint-gated public endpoint.
         self._anon_fingerprint: Optional[str] = anon_fingerprint
 
+        # Optional caller-supplied headers merged UNDER SDK-owned headers on
+        # every RPC. Protected headers (Authorization / Content-Type /
+        # protocol version / X-Write-Affinity) are enforced by the rpc-client
+        # merge. Default-off.
+        self._rpc_headers: Optional[Dict[str, str]] = rpc_headers
+
     # -- Factory classmethod ---------------------------------------------------
 
     @classmethod
@@ -488,6 +495,7 @@ class TaskClient:
         token_provider: Optional[Callable[[], Any]] = None,
         on_auth_error: Optional[Callable[[Exception], None]] = None,
         anon_fingerprint: Optional[str] = None,
+        rpc_headers: Optional[Dict[str, str]] = None,
     ) -> "TaskClient":
         """Create a TaskClient from environment variables or CDM config.
 
@@ -644,6 +652,7 @@ class TaskClient:
             auth_provider=auth_provider_instance,
             default_owner_id=default_owner,
             anon_fingerprint=anon_fingerprint,
+            rpc_headers=rpc_headers,
         )
         client._consumer_auth = consumer_auth_instance
         return client
@@ -1077,6 +1086,7 @@ class TaskClient:
             self._subscribe_key, "SendMessage", rpc_params,
             base_url=self._base_url, agent_auth=self._agent_auth,
             auth_provider=self._auth_provider,
+            rpc_headers=self._rpc_headers,
         )
 
         is_idempotent = result.get("idempotent", False)
@@ -1114,6 +1124,7 @@ class TaskClient:
                     "auth_provider": self._auth_provider,
                     "base_url": self._base_url,
                     "agent_auth": self._agent_auth,
+                    "rpc_headers": self._rpc_headers,
                 },
                 idempotent=True,
                 queued=result.get("queued"),
@@ -1139,6 +1150,7 @@ class TaskClient:
             "auth_provider": self._auth_provider,
             "base_url": self._base_url,
             "agent_auth": self._agent_auth,
+            "rpc_headers": self._rpc_headers,
         }
 
         # Resolve channel: prefer server-provided, fall back to derived.
@@ -1386,6 +1398,7 @@ class TaskClient:
             "base_url": self._base_url,
             "agent_auth": self._agent_auth,
             "auth_provider": self._auth_provider,
+            "rpc_headers": self._rpc_headers,
         }
 
         # Fetch history up front. History is authoritative for session
@@ -1709,6 +1722,7 @@ class TaskClient:
             self._subscribe_key, "GetTask", {"taskId": task_id},
             base_url=self._base_url, agent_auth=self._agent_auth,
             auth_provider=self._auth_provider,
+            rpc_headers=self._rpc_headers,
         )
         task_data = result.get("task", result) if isinstance(result, dict) else result
         return TaskInfo.from_dict(task_data)
@@ -1732,6 +1746,7 @@ class TaskClient:
             self._subscribe_key, "ListTasks", rpc_params,
             base_url=self._base_url, agent_auth=self._agent_auth,
             auth_provider=self._auth_provider,
+            rpc_headers=self._rpc_headers,
         )
         tasks = [TaskInfo.from_dict(t) for t in result.get("tasks", [])]
         return ListTasksResult(
@@ -1746,6 +1761,7 @@ class TaskClient:
             self._subscribe_key, "CancelTask", {"taskId": task_id},
             base_url=self._base_url, agent_auth=self._agent_auth,
             auth_provider=self._auth_provider,
+            rpc_headers=self._rpc_headers,
         )
 
     def pause_task(self, task_id: str) -> None:
@@ -1754,6 +1770,7 @@ class TaskClient:
             self._subscribe_key, "PauseTask", {"taskId": task_id},
             base_url=self._base_url, agent_auth=self._agent_auth,
             auth_provider=self._auth_provider,
+            rpc_headers=self._rpc_headers,
         )
 
     def resume_task(self, task_id: str) -> None:
@@ -1762,6 +1779,7 @@ class TaskClient:
             self._subscribe_key, "ResumeTask", {"taskId": task_id},
             base_url=self._base_url, agent_auth=self._agent_auth,
             auth_provider=self._auth_provider,
+            rpc_headers=self._rpc_headers,
         )
 
     def retry_task(self, task_id: str) -> None:
@@ -1770,6 +1788,7 @@ class TaskClient:
             self._subscribe_key, "RetryTask", {"taskId": task_id},
             base_url=self._base_url, agent_auth=self._agent_auth,
             auth_provider=self._auth_provider,
+            rpc_headers=self._rpc_headers,
         )
 
     def terminate_task(self, task_id: str) -> None:
@@ -1778,6 +1797,7 @@ class TaskClient:
             self._subscribe_key, "TerminateTask", {"taskId": task_id},
             base_url=self._base_url, agent_auth=self._agent_auth,
             auth_provider=self._auth_provider,
+            rpc_headers=self._rpc_headers,
         )
 
     # -- Subscribe helper ---------------------------------------------------

--- a/sdks/python/blocks_network/task_session.py
+++ b/sdks/python/blocks_network/task_session.py
@@ -1041,6 +1041,7 @@ class TaskSession:
             base_url=self._rpc_config.get("base_url"),
             agent_auth=self._rpc_config.get("agent_auth"),
             auth_provider=self._rpc_config.get("auth_provider"),
+            rpc_headers=self._rpc_config.get("rpc_headers"),
         )
 
     def terminate(self) -> None:
@@ -1057,6 +1058,7 @@ class TaskSession:
             base_url=self._rpc_config.get("base_url"),
             agent_auth=self._rpc_config.get("agent_auth"),
             auth_provider=self._rpc_config.get("auth_provider"),
+            rpc_headers=self._rpc_config.get("rpc_headers"),
         )
 
     # -- Cleanup --

--- a/sdks/python/tests/test_rpc_client.py
+++ b/sdks/python/tests/test_rpc_client.py
@@ -177,6 +177,85 @@ class TestCallRpc:
         with pytest.raises(ValueError, match="base_url is required"):
             call_rpc("sub-c-test", "SendMessage", {})
 
+    @patch("blocks_network.rpc_client.urllib.request.urlopen")
+    def test_merges_rpc_headers(self, mock_urlopen):
+        mock_urlopen.return_value = _make_urlopen_response(
+            {"jsonrpc": "2.0", "id": "x", "result": None}
+        )
+        call_rpc(
+            "sub-c-test", "Ping", {}, base_url="http://localhost:3001",
+            rpc_headers={"X-Active-Org": "org-B"},
+        )
+        req = mock_urlopen.call_args[0][0]
+        # urllib title-cases header keys.
+        assert req.headers["X-active-org"] == "org-B"
+        assert req.headers["Content-type"] == "application/json"
+
+    @patch("blocks_network.rpc_client.urllib.request.urlopen")
+    def test_rpc_headers_cannot_override_protected(self, mock_urlopen):
+        mock_urlopen.return_value = _make_urlopen_response(
+            {"jsonrpc": "2.0", "id": "x", "result": None}
+        )
+        call_rpc(
+            "sub-c-test", "Ping", {}, base_url="http://localhost:3001",
+            auth_provider=StaticAuthProvider("real-jwt"),
+            rpc_headers={
+                "authorization": "Bearer FORGED",
+                "Content-Type": "text/evil",
+            },
+        )
+        req = mock_urlopen.call_args[0][0]
+        assert req.headers["Authorization"] == "Bearer real-jwt"
+        assert req.headers["Content-type"] == "application/json"
+
+    @patch("blocks_network.rpc_client.urllib.request.urlopen")
+    def test_rpc_headers_cannot_override_write_affinity(self, mock_urlopen):
+        # §14b: X-Write-Affinity is SDK-managed routing state. A caller MUST NOT
+        # be able to smuggle it via rpc_headers and force primary-DB routing.
+        from blocks_network.write_affinity import reset_affinity
+
+        reset_affinity()
+        mock_urlopen.return_value = _make_urlopen_response(
+            {"jsonrpc": "2.0", "id": "x", "result": None}
+        )
+        # Lowercase caller key proves the strip is case-insensitive: inject_affinity
+        # only manages the exact-cased "X-Write-Affinity", so without the protected-set
+        # entry a lowercase caller value would survive on the fetch branch.
+        call_rpc(
+            "sub-c-test", "Ping", {}, base_url="http://localhost:3001",
+            rpc_headers={"x-write-affinity": "9999999999"},
+        )
+        req = mock_urlopen.call_args[0][0]
+        # No stored affinity exists, so no affinity header should be present.
+        # urllib title-cases keys → check the normalized form and the raw forms.
+        assert "X-write-affinity" not in req.headers
+        assert "x-write-affinity" not in req.headers
+        assert "X-Write-Affinity" not in req.headers
+        reset_affinity()
+
+    def test_agent_auth_rpc_headers_cannot_override_write_affinity(self):
+        # agent_auth branch: affinity is managed inside authenticated_request, so
+        # inject_affinity does NOT run here — the strip must still remove a
+        # caller-supplied affinity header (case-insensitive).
+        from blocks_network.write_affinity import reset_affinity
+
+        reset_affinity()
+        captured = {}
+
+        class _FakeAgentAuth:
+            def authenticated_request(self, url, method, body, headers):
+                captured["headers"] = headers
+                return ({"jsonrpc": "2.0", "id": "x", "result": None}, 200)
+
+        call_rpc(
+            "sub-c-test", "Ping", {}, base_url="http://localhost:3001",
+            agent_auth=_FakeAgentAuth(),
+            rpc_headers={"x-write-affinity": "9999999999", "X-Write-Affinity": "9999999999"},
+        )
+        headers = captured["headers"]
+        assert all(k.lower() != "x-write-affinity" for k in headers)
+        reset_affinity()
+
 
 # ============================================================================
 # with_retry

--- a/sdks/python/tests/test_task_session.py
+++ b/sdks/python/tests/test_task_session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -2209,3 +2210,151 @@ class TestOnTerminalImmediateFire:
         assert "consumer_user_id" not in original_opts
         # The session's internal copy must carry the key.
         assert session._sdk_options["consumer_user_id"] == "usr_xyz"
+
+
+class TestCancelTerminateForwardRpcHeaders:
+    """Regression: cancel()/terminate() forward rpc_headers (e.g. X-Active-Org) from rpc_config, matching Node's whole-config passthrough."""
+
+    def _make_session_with_headers(self, headers):
+        return TaskSession(
+            task_id="task-9",
+            owner_id="alice",
+            read_token=None,
+            agent_name="echo",
+            pubnub=_make_mock_pubnub(),
+            sdk_options={"subscribe_key": "sub", "publish_key": "pub"},
+            rpc_config={
+                "subscribe_key": "rpc-sub",
+                "auth_provider": None,
+                "base_url": "http://localhost:3001",
+                "agent_auth": None,
+                "rpc_headers": headers,
+            },
+        )
+
+    @patch("blocks_network.task_session.call_rpc")
+    def test_cancel_forwards_rpc_headers(self, mock_call_rpc) -> None:
+        session = self._make_session_with_headers({"X-Active-Org": "org-B"})
+        session.cancel()
+        assert mock_call_rpc.call_args.kwargs["rpc_headers"] == {"X-Active-Org": "org-B"}
+
+    @patch("blocks_network.task_session.call_rpc")
+    def test_terminate_forwards_rpc_headers(self, mock_call_rpc) -> None:
+        session = self._make_session_with_headers({"X-Active-Org": "org-B"})
+        session.terminate()
+        assert mock_call_rpc.call_args.kwargs["rpc_headers"] == {"X-Active-Org": "org-B"}
+
+    @patch("blocks_network.task_session.call_rpc")
+    def test_cancel_no_headers_is_noop(self, mock_call_rpc) -> None:
+        """When rpc_config carries no rpc_headers, cancel() passes None (default-off)."""
+        session = self._make_session_with_headers(None)
+        session.cancel()
+        assert mock_call_rpc.call_args.kwargs["rpc_headers"] is None
+
+    @patch("blocks_network.task_session.call_rpc")
+    def test_cancel_tolerates_legacy_rpc_config_without_key(
+        self, mock_call_rpc
+    ) -> None:
+        """An older rpc_config shape (no rpc_headers key) must not KeyError -- .get() yields None."""
+        session = TaskSession(
+            task_id="task-9",
+            owner_id="alice",
+            read_token=None,
+            agent_name="echo",
+            pubnub=_make_mock_pubnub(),
+            sdk_options={"subscribe_key": "sub", "publish_key": "pub"},
+            rpc_config={
+                "subscribe_key": "rpc-sub",
+                "auth_provider": None,
+                "base_url": "http://localhost:3001",
+                "agent_auth": None,
+            },
+        )
+        session.cancel()
+        assert mock_call_rpc.call_args.kwargs["rpc_headers"] is None
+
+
+class TestTaskClientBuildsRpcConfigWithHeaders:
+    """The other half of the bug: TaskClient places rpc_headers into the rpc_config handed to each TaskSession (send_message + connect)."""
+
+    @staticmethod
+    def _full_send_response():
+        return {
+            "taskId": "task-123",
+            "idempotent": False,
+            "queued": False,
+            "extensions": {
+                "blocks": {
+                    "streamChannels": {"status": "u.user-1.task-123"},
+                    "readToken": "T4-read-token",
+                }
+            },
+        }
+
+    @patch("blocks_network.task_client.TaskClient._create_session_pubnub")
+    @patch("blocks_network.rpc_client.urllib.request.urlopen")
+    def test_send_message_rpc_config_includes_rpc_headers(
+        self, mock_urlopen, mock_create_pn
+    ) -> None:
+        from blocks_network.task_client import TaskClient
+
+        body = json.dumps(
+            {"jsonrpc": "2.0", "id": "x", "result": self._full_send_response()}
+        ).encode("utf-8")
+        resp = MagicMock()
+        resp.read.return_value = body
+        resp.__enter__ = MagicMock(return_value=resp)
+        resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = resp
+
+        mock_create_pn.return_value = _make_mock_pubnub()
+
+        client = TaskClient(
+            subscribe_key="sub-c-test",
+            billing_mode="free",
+            base_url="http://localhost:3001",
+            rpc_headers={"X-Active-Org": "org-B"},
+        )
+        session = client.send_message(
+            agent_name="agent-b",
+            request_parts=[{"type": "text", "text": "Hello"}],
+            owner_id="user-1",
+        )
+
+        assert session._rpc_config is not None
+        assert session._rpc_config.get("rpc_headers") == {"X-Active-Org": "org-B"}
+        session.close()
+
+    @patch("blocks_network.task_client.call_rpc")
+    def test_connect_rpc_config_includes_rpc_headers(self, mock_rpc) -> None:
+        from blocks_network.auth_provider import StaticAuthProvider
+        from blocks_network.task_client import TaskClient
+
+        mock_rpc.return_value = {
+            "task": {
+                "taskId": "task-1",
+                "agentName": "echo",
+                "owner": "alice",
+                "state": "completed",
+            },
+        }
+
+        client = TaskClient(
+            subscribe_key="sub-key",
+            billing_mode="free",
+            auth_provider=StaticAuthProvider("jwt-token"),
+            base_url="http://localhost:3000",
+            rpc_headers={"X-Active-Org": "org-B"},
+        )
+
+        mock_pn = _make_mock_pubnub()
+        with patch.object(client, "_create_session_pubnub", return_value=mock_pn), \
+             patch.object(client, "_fetch_task_read_token", return_value={
+                 "pamToken": "t4-fresh",
+                 "channel": "u.org1.task-1",
+                 "ttlMinutes": 60,
+             }):
+            session = client.connect("task-1")
+
+        assert session._rpc_config is not None
+        assert session._rpc_config.get("rpc_headers") == {"X-Active-Org": "org-B"}

--- a/skills/references/agent-development-guide.md
+++ b/skills/references/agent-development-guide.md
@@ -557,11 +557,11 @@ npm start  # Terminal 2
 
 ---
 
-## Local SDK Setup
+## SDK Dependency
 
-The `@blocks-network/sdk` package is available locally at
-`blocks-network/` in the project root. Reference it as a file
-dependency:
+The `@blocks-network/sdk` package is published on npm
+(<https://www.npmjs.com/package/@blocks-network/sdk>). Reference it in
+your `package.json` (`blocks init` scaffolds this for you):
 
 ```json
 {
@@ -574,7 +574,7 @@ dependency:
     "check": "blocks check"
   },
   "dependencies": {
-    "@blocks-network/sdk": "file:../blocks-network",
+    "@blocks-network/sdk": "latest",
     "dotenv": "^16.4.5",
     "tsx": "^4.15.7"
   }

--- a/skills/references/node-reference.md
+++ b/skills/references/node-reference.md
@@ -477,6 +477,7 @@ const client = await TaskClient.create({
 
 - `billingMode` is required ('free' → playground keyset, 'paid' → network keyset) and must match the target agent's server-derived billingMode (exception: authenticated same-org callers are exempt from this check). Read it from the registry: `(await getAgent(name)).billingMode`.
 - Exactly one auth mode: `apiKey`, `tokenEndpoint`, or `tokenProvider`
+- `rpcHeaders?: Record<string, string>` — optional extra request headers merged onto every RPC call (not the token mint). Merged UNDER SDK-owned headers, so a caller cannot override `Authorization`, `Content-Type`, `Blocks-Protocol-Version`, or `X-Write-Affinity` (case-insensitive). Request metadata, not auth; the canonical dashboard use is `X-Active-Org` to scope a multi-org user's submission to the agent's owning org.
 - Returns `Promise<TaskClient>`
 
 ---

--- a/skills/references/python-reference.md
+++ b/skills/references/python-reference.md
@@ -420,6 +420,7 @@ client = TaskClient.create(
 
 - `billing_mode` is the first positional arg (required) and selects the keyset ('free' → playground, 'paid' → network)
 - Exactly one auth mode: `api_key`, `token_endpoint`, or `token_provider`
+- `rpc_headers: Optional[Dict[str, str]] = None` — optional extra request headers merged onto every RPC call (not the token mint). Merged UNDER SDK-owned headers, so a caller cannot override `Authorization`, `Content-Type`, `Blocks-Protocol-Version`, or `X-Write-Affinity` (case-insensitive). Request metadata, not auth; the canonical dashboard use is `X-Active-Org` to scope a multi-org user's submission to the agent's owning org.
 - Does not call `load_dotenv()` -- caller manages env vars
 - Synchronous (no `await`)
 


### PR DESCRIPTION
## Node SDK & Python SDK

### Added
- `TaskClient` accepts an optional `rpcHeaders` (Node) / `rpc_headers` (Python) option to attach custom headers to RPC calls, including task cancel and terminate; SDK-owned headers cannot be overridden.
